### PR TITLE
Added redirection on plugin activation.

### DIFF
--- a/src/ActivationHook.php
+++ b/src/ActivationHook.php
@@ -2,7 +2,11 @@
 
 namespace StellarWP\Telemetry;
 
+use StellarWP\Telemetry\Contracts\Runnable;
+
 class ActivationHook implements Runnable {
+	public const REDIRECT_ON_ACTIVATION = true;
+
 	/**
 	 * @var Starter
 	 */
@@ -30,7 +34,7 @@ class ActivationHook implements Runnable {
 		}
 
 		// Add redirect option for the user who activated the plugin, if redirection is enabled.
-		if ( $this->starter->should_redirect_on_activation() ) {
+		if ( $this->should_redirect_on_activation() ) {
 			// Do not add redirect option if doing a bulk activation.
 			if (
 				( isset( $_REQUEST['action'] ) && 'activate-selected' === $_REQUEST['action'] ) &&
@@ -38,7 +42,15 @@ class ActivationHook implements Runnable {
 				return;
 			}
 
-			add_option( $this->starter->get_redirection_option_name(), wp_get_current_user()->ID );
+			add_option( $this->get_redirection_option_name(), wp_get_current_user()->ID );
 		}
+	}
+
+	protected function should_redirect_on_activation(): bool {
+		return apply_filters( 'stellarwp_telemetry_redirect_on_activation', self::REDIRECT_ON_ACTIVATION );
+	}
+
+	public function get_redirection_option_name(): string {
+		return apply_filters( 'stellarwp_telemetry_redirection_option_name', $this->starter->get_option_name() . '_redirection' );
 	}
 }

--- a/src/ActivationRedirect.php
+++ b/src/ActivationRedirect.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace StellarWP\Telemetry;
+
+use StellarWP\Telemetry\Contracts\Redirection;
+
+class ActivationRedirect implements Redirection {
+	public const REDIRECTION_URL = 'options-general.php?page=stellarwp-telemetry-starter';
+
+	/**
+	 * @var ActivationHook
+	 */
+	protected $activation_hook;
+
+	public function __construct( ActivationHook $activation_hook ) {
+		$this->activation_hook = $activation_hook;
+	}
+
+	public function trigger(): void {
+		$this->remove_activation_redirect_option();
+
+		exit( wp_safe_redirect( admin_url( $this->get_url() ) ) );
+	}
+
+	public function get_url(): string {
+		return apply_filters( 'stellarwp_telemetry_activation_redirect', self::REDIRECTION_URL );
+	}
+
+	protected function remove_activation_redirect_option(): void {
+		delete_option( $this->activation_hook->get_redirection_option_name() );
+	}
+
+	public function should_trigger(): bool {
+		if ( ! wp_doing_ajax() &&
+		     ( intval( get_option( $this->activation_hook->get_redirection_option_name(), false ) ) === wp_get_current_user()->ID )
+		) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/Contracts/DataProvider.php
+++ b/src/Contracts/DataProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StellarWP\Telemetry;
+namespace StellarWP\Telemetry\Contracts;
 
 interface DataProvider {
 	public function get_data(): array;

--- a/src/Contracts/Redirection.php
+++ b/src/Contracts/Redirection.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace StellarWP\Telemetry\Contracts;
+
+interface Redirection {
+	public function get_url(): string;
+	public function trigger(): void;
+}

--- a/src/Contracts/Request.php
+++ b/src/Contracts/Request.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StellarWP\Telemetry;
+namespace StellarWP\Telemetry\Contracts;
 
 interface Request {
 	public function get_url(): string;

--- a/src/Contracts/Runnable.php
+++ b/src/Contracts/Runnable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StellarWP\Telemetry;
+namespace StellarWP\Telemetry\Contracts;
 
 interface Runnable {
 	public function run(): void;

--- a/src/Contracts/Template.php
+++ b/src/Contracts/Template.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace StellarWP\Telemetry\Contracts;
+
+interface Template {
+	public function render();
+	public function enqueue();
+}

--- a/src/DebugDataProvider.php
+++ b/src/DebugDataProvider.php
@@ -2,6 +2,7 @@
 
 namespace StellarWP\Telemetry;
 
+use StellarWP\Telemetry\Contracts\DataProvider;
 use WP_Debug_Data;
 
 class DebugDataProvider implements DataProvider {

--- a/src/ExampleStarter.php
+++ b/src/ExampleStarter.php
@@ -2,6 +2,9 @@
 
 namespace StellarWP\Telemetry;
 
+use StellarWP\Telemetry\Contracts\DataProvider;
+use StellarWP\Telemetry\Contracts\Template;
+
 class ExampleStarter extends Starter {
 	public function __construct( Template $optin_template, DataProvider $provider ) {
 		// TODO: Remove this class, make this all in the Starter class, and create

--- a/src/OptInTemplate.php
+++ b/src/OptInTemplate.php
@@ -2,6 +2,8 @@
 
 namespace StellarWP\Telemetry;
 
+use StellarWP\Telemetry\Contracts\Template;
+
 class OptInTemplate implements Template {
 
 	public function enqueue() {

--- a/src/RegisterSiteRequest.php
+++ b/src/RegisterSiteRequest.php
@@ -2,6 +2,10 @@
 
 namespace StellarWP\Telemetry;
 
+use StellarWP\Telemetry\Contracts\DataProvider;
+use StellarWP\Telemetry\Contracts\Request;
+use StellarWP\Telemetry\Contracts\Runnable;
+
 class RegisterSiteRequest implements Request, Runnable {
 
 	/**

--- a/src/Starter.php
+++ b/src/Starter.php
@@ -2,13 +2,14 @@
 
 namespace StellarWP\Telemetry;
 
+use StellarWP\Telemetry\Contracts\DataProvider;
+use StellarWP\Telemetry\Contracts\Template;
+
 abstract class Starter {
 	public const OPTION                 = 'stellarwp_telemetry';
-	public const REDIRECT_ON_ACTIVATION = true;
 	public const CRON_INTERVAL          = WEEK_IN_SECONDS;
 	public const PLUGIN_SLUG            = 'stellarwp-telemetry-starter';
 	public const PLUGIN_VERSION         = '1.0.0';
-	public const ACTIVATION_REDIRECT    = 'options-general.php?page=stellarwp-telemetry-starter';
 	public const TELEMETRY_URL          = 'https://telemetry-api.moderntribe.qa/api/v1';
 	public const YES                    = "1";
 	public const NO                     = "-1";
@@ -16,18 +17,11 @@ abstract class Starter {
 	/** @var Template $optin_template */
 	protected $optin_template;
 
-	/** @var Runnable $activation_hook */
-	protected $activation_hook;
-
 	/** @var DataProvider $provider */
 	protected $provider;
 
 	/** @var bool $enqueues_applied */
 	protected $enqueues_applied = false;
-
-	public function activation_hook(): void {
-		$this->activation_hook->run( $this );
-	}
 
 	public function register_cronjob_handlers(): void {
 		add_action( $this->get_cron_hook_name(), function () {
@@ -141,29 +135,6 @@ abstract class Starter {
 
 	public function run_optin(): void {
 		$this->optin_template->render();
-	}
-
-	protected function perform_activation_redirect(): void {
-		if ( $this->should_redirect_on_activation() &&
-		     ! wp_doing_ajax() &&
-		     ( intval( get_option( $this->get_redirection_option_name(), false ) ) === wp_get_current_user()->ID )
-		) {
-			delete_option( $this->get_redirection_option_name() );
-			wp_safe_redirect( admin_url( $this->get_activation_redirect() ) );
-			exit;
-		}
-	}
-
-	public function should_redirect_on_activation(): bool {
-		return (bool) apply_filters( 'stellarwp_telemetry_redirect_on_activation', $this::REDIRECT_ON_ACTIVATION );
-	}
-
-	public function get_redirection_option_name(): string {
-		return apply_filters( 'stellarwp_telemetry_redirection_option_name', $this->get_option_name() . '_redirection' );
-	}
-
-	public function get_activation_redirect(): string {
-		return apply_filters( 'stellarwp_telemetry_activation_redirect', $this::ACTIVATION_REDIRECT );
 	}
 
 	public function get_token(): string {

--- a/src/TelemetrySendDataRequest.php
+++ b/src/TelemetrySendDataRequest.php
@@ -2,6 +2,10 @@
 
 namespace StellarWP\Telemetry;
 
+use StellarWP\Telemetry\Contracts\DataProvider;
+use StellarWP\Telemetry\Contracts\Request;
+use StellarWP\Telemetry\Contracts\Runnable;
+
 class TelemetrySendDataRequest implements Request, Runnable {
 
 	/**

--- a/src/Template.php
+++ b/src/Template.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace StellarWP\Telemetry;
-
-interface Template {
-	public function render();
-	public function enqueue();
-}

--- a/tests/wpunit/RegisterSiteTest.php
+++ b/tests/wpunit/RegisterSiteTest.php
@@ -2,14 +2,14 @@
 
 use Codeception\TestCase\WPTestCase;
 use lucatume\DI52\Container;
-use StellarWP\Telemetry\Runnable;
 use StellarWP\Telemetry\ActivationHook;
-use StellarWP\Telemetry\OptInTemplate;
-use StellarWP\Telemetry\ExampleStarter;
+use StellarWP\Telemetry\Contracts\DataProvider;
+use StellarWP\Telemetry\Contracts\Runnable;
 use StellarWP\Telemetry\DebugDataProvider;
-use StellarWP\Telemetry\Starter;
+use StellarWP\Telemetry\ExampleStarter;
+use StellarWP\Telemetry\OptInTemplate;
 use StellarWP\Telemetry\RegisterSiteRequest;
-use StellarWP\Telemetry\DataProvider;
+use StellarWP\Telemetry\Starter;
 
 class RegisterSiteTest extends WPTestCase {
 	/**

--- a/tests/wpunit/TelemetrySendDataTest.php
+++ b/tests/wpunit/TelemetrySendDataTest.php
@@ -2,14 +2,14 @@
 
 use Codeception\TestCase\WPTestCase;
 use lucatume\DI52\Container;
-use StellarWP\Telemetry\Runnable;
 use StellarWP\Telemetry\ActivationHook;
-use StellarWP\Telemetry\OptInTemplate;
-use StellarWP\Telemetry\ExampleStarter;
+use StellarWP\Telemetry\Contracts\DataProvider;
+use StellarWP\Telemetry\Contracts\Runnable;
 use StellarWP\Telemetry\DebugDataProvider;
-use StellarWP\Telemetry\Starter;
+use StellarWP\Telemetry\ExampleStarter;
+use StellarWP\Telemetry\OptInTemplate;
 use StellarWP\Telemetry\RegisterSiteRequest;
-use StellarWP\Telemetry\DataProvider;
+use StellarWP\Telemetry\Starter;
 use StellarWP\Telemetry\TelemetrySendDataRequest;
 
 class TelemetrySendDataTest extends WPTestCase {


### PR DESCRIPTION
Reason I'm adding this as part of the telemetry library, is that the Opt In is part of our responsibility so we need to be able to handle a way to automatically redirect to a known area where we'll inject the template's code, but that will be handled in the plugin.

This is also my first effort to remove the God-class Starter, and to move individual parts of the library to their own usable classes.