### PR TITLE
Opt-In Modal Improvements

### DIFF
--- a/src/OptInTemplate.php
+++ b/src/OptInTemplate.php
@@ -14,7 +14,15 @@ class OptInTemplate implements Template {
 
 	public function render(): void {
 		load_template( __DIR__ . '/views/optin.php', true, [
-			'url' => plugin_dir_url( __DIR__ ) . 'public/logo.png',
+			'plugin_logo'        => plugin_dir_url( __DIR__ ) . 'public/logo.png',
+			'plugin_logo_width'  => 151,
+			'plugin_logo_height' => 32,
+			'plugin_logo_alt'    => 'StellarWP Logo',
+			'plugin_name'        => 'The Events Calendar',
+			'user_name'          => wp_get_current_user()->display_name,
+			'permissions_url'    => '#',
+			'tos_url'            => '#',
+			'privacy_url'        => '#',
 		] );
 	}
 

--- a/src/OptInTemplate.php
+++ b/src/OptInTemplate.php
@@ -13,33 +13,9 @@ class OptInTemplate implements Template {
 	}
 
 	public function render(): void {
-		$this->render_styles();
-		$this->render_scripts();
-
-		$url = plugin_dir_url( __DIR__ ) . 'public/logo.png';
-
-		echo <<<HTML
-<div class="stellarwp-telemetry-starter wrapper">
-	<section class="stellarwp-telemetry-starter modal">
-		<header>
-			<img src="$url" width="151" height="32" />
-			<h1 class="stellarwp-telemetry-starter-header">We hope you love [The Events Calendar].</h1>
-		</header>
-		<main>
-			<p>Hi, [username]! This is an invitation to help our StellarWP community. If you opt-in, some data about your usage of [The Events Calendar] and Future StellarWP Products will be shared with our teams (so they can work their butts off to improve). We will also share some helpful info on WordPress, and our products from time to time. And if you skip this, that’s okay! Our Products still works just fine.</p>
-			<ul class="links">
-				<li><a href="#">What permissions are being granted?</a></li>
-				<li><a href="#">Terms of Service</a></li>
-				<li><a href="#">Privacy Policy</a></li>
-			</ul>
-		</main>
-		<footer>
-			<button class="btn-primary">Allow &amp; Continue</button>
-			<button class="btn-text">Skip</button>
-		</footer>
-	</section>
-</div>
-HTML;
+		load_template( __DIR__ . '/views/optin.php', true, [
+			'url' => plugin_dir_url( __DIR__ ) . 'public/logo.png',
+		] );
 	}
 
 	protected function get_option_name(): string {
@@ -58,89 +34,5 @@ HTML;
 		if ( $this->should_render() ) {
 			$this->render();
 		}
-	}
-
-	public function render_styles(): void {
-		echo <<<HTML
-<style>
-.stellarwp-telemetry-starter.wrapper {
-	position: fixed;
-	bottom: 0; 
-	right: 0;
-	width: 100%;
-	height: 100%;
-	background: rgba(0, 0, 0, 0.5);
-	z-index: 999999;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	transition: all -1.3s ease-in-out;
-}
-
-.stellarwp-telemetry-starter.modal {
-	position: absolute;
-	z-index: 999999;
-	display: flex;
-	flex-direction: column;
-	padding: 32px;
-	width: 90%;
-	top: 47px;
-	left: 32px;
-	background: #fff;
-	box-shadow: 0 0 32px rgba(0, 0, 0, 0.1);
-	border-radius: 4px;
-}
-
-.stellarwp-telemetry-starter h1 {
-	font-family: 'SF Pro Text', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
-	font-size: 18px;
-	font-weight: 500;
-	line-height: 24px;
-	letter-spacing: -0.02em;
-	color: #000;
-}
-
-.stellarwp-telemetry-starter {
-	font-family: 'SF Pro Text', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
-	font-size: 14px;
-	font-weight: 400;
-	line-height: 18px;
-	color: #4E4E4E;
-}
-
-.stellarwp-telemetry-starter .btn-primary, 
-.stellarwp-telemetry-starter .btn-text {
-	padding: 6px 12px;
-	background: #0047FF;
-	border-radius: 4px;
-	color: #fff;
-}
-
-.stellarwp-telemetry-starter .btn-text {
-	background: #fff;
-	color: #000;
-}
-
-.stellarwp-telemetry-starter .links {
-	display: flex;
-	gap: 16px;
-	font-size: 12px;
-	line-height: 16px;
-}
-
-.stellarwp-telemetry-starter .links a {
-	color: #0047FF;
-	text-decoration: none;
-}
-</style>
-HTML;
-	}
-
-	public function render_scripts(): void {
-		echo <<<HTML
-<script>
-console.log('Hello World');
-</script>
-HTML;
 	}
 }

--- a/src/OptInTemplate.php
+++ b/src/OptInTemplate.php
@@ -12,8 +12,8 @@ class OptInTemplate implements Template {
 		// TODO: Once FE template is done, enqueue it here.
 	}
 
-	public function render(): void {
-		load_template( __DIR__ . '/views/optin.php', true, [
+	protected function get_args(): array {
+		return apply_filters( 'stellarwp_telemetry_optin_args', [
 			'plugin_logo'        => plugin_dir_url( __DIR__ ) . 'public/logo.png',
 			'plugin_logo_width'  => 151,
 			'plugin_logo_height' => 32,
@@ -24,6 +24,10 @@ class OptInTemplate implements Template {
 			'tos_url'            => '#',
 			'privacy_url'        => '#',
 		] );
+	}
+
+	public function render(): void {
+		load_template( __DIR__ . '/views/optin.php', true, $this->get_args() );
 	}
 
 	protected function get_option_name(): string {

--- a/src/views/optin.php
+++ b/src/views/optin.php
@@ -14,7 +14,7 @@
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		transition: all -1.3s ease-in-out;
+		transition: all 0.3s ease-in-out;
 	}
 
 	.stellarwp-telemetry-starter.modal {
@@ -55,6 +55,14 @@
 		border-radius: 4px;
 		color: #fff;
 		text-decoration: none;
+		border: 0;
+		outline: none;
+		transition: all 0.1s ease-in-out;
+		cursor: pointer;
+	}
+
+	.stellarwp-telemetry-starter .btn-primary:hover {
+		background: #0032b7;
 	}
 
 	.stellarwp-telemetry-starter .btn-text {
@@ -66,6 +74,7 @@
 	.stellarwp-telemetry-starter .btn-text:hover {
 		text-decoration: underline;
 	}
+
 	.stellarwp-telemetry-starter .links {
 		display: flex;
 		gap: 16px;
@@ -81,14 +90,27 @@
 
 
 <script>
-	console.log('Hello World');
+	// JS document on ready event
+	document.addEventListener("DOMContentLoaded", function () {
+		let wrapper = document.getElementById("modal-wrapper");
+
+		document.getElementById("close-modal").addEventListener("click", function (event) {
+			event.preventDefault();
+			close_modal(wrapper);
+		});
+	});
+
+	function close_modal(wrapper) {
+		wrapper.parentNode.removeChild(wrapper);
+	}
 </script>
 
-<div class="stellarwp-telemetry-starter wrapper">
+<div id="modal-wrapper" class="stellarwp-telemetry-starter wrapper">
 	<section class="stellarwp-telemetry-starter modal">
 		<header>
-			<img src="<?php echo $args['plugin_logo']; ?>" width="<?php echo $args['plugin_logo_width']; ?>" height="<?php echo $args['plugin_logo_height']; ?>" alt="<?php echo $args['plugin_logo_alt']; ?>" />
-			<h1 class="stellarwp-telemetry-starter-header">We hope you love <?php echo $args['plugin_name'] ; ?>.</h1>
+			<img src="<?php echo $args['plugin_logo']; ?>" width="<?php echo $args['plugin_logo_width']; ?>"
+			     height="<?php echo $args['plugin_logo_height']; ?>" alt="<?php echo $args['plugin_logo_alt']; ?>"/>
+			<h1 class="stellarwp-telemetry-starter-header">We hope you love <?php echo $args['plugin_name']; ?>.</h1>
 		</header>
 		<main>
 			<p>Hi, <?php echo $args['user_name']; ?>! This is an invitation to help our StellarWP community.
@@ -97,14 +119,19 @@
 				We will also share some helpful info on WordPress, and our products from time to time.
 				And if you skip this, that’s okay! Our products still work just fine.</p>
 			<ul class="links">
-				<li><a href="<?php echo $args['permissions_url'] ;?>" target="_blank">What permissions are being granted?</a></li>
-				<li><a href="<?php echo $args['tos_url'] ;?>" target="_blank">Terms of Service</a></li>
-				<li><a href="<?php echo $args['privacy_url'] ;?>" target="_blank">Privacy Policy</a></li>
+				<li><a href="<?php echo $args['permissions_url']; ?>" target="_blank">What permissions are being
+						granted?</a></li>
+				<li><a href="<?php echo $args['tos_url']; ?>" target="_blank">Terms of Service</a></li>
+				<li><a href="<?php echo $args['privacy_url']; ?>" target="_blank">Privacy Policy</a></li>
 			</ul>
 		</main>
 		<footer>
-			<a class="btn-primary" href="#">Allow &amp; Continue</a>
-			<a class="btn-text" href="#">Skip</a>
+			<form method="get">
+				<?php wp_nonce_field( 'optin-modal' ); ?>
+				<input type="hidden" name="page" value="<?php echo esc_attr( $_GET['page'] ); ?>">
+				<button id="agree-modal" class="btn-primary" type="submit" name="optin-agreed" value="1">Allow &amp; Continue</button>
+				<button id="close-modal" class="btn-text" type="button">Skip</button>
+			</form>
 		</footer>
 	</section>
 </div>

--- a/src/views/optin.php
+++ b/src/views/optin.php
@@ -54,6 +54,7 @@
 		background: #0047FF;
 		border-radius: 4px;
 		color: #fff;
+		text-decoration: none;
 	}
 
 	.stellarwp-telemetry-starter .btn-text {
@@ -61,6 +62,10 @@
 		color: #000;
 	}
 
+	.stellarwp-telemetry-starter .links a:hover,
+	.stellarwp-telemetry-starter .btn-text:hover {
+		text-decoration: underline;
+	}
 	.stellarwp-telemetry-starter .links {
 		display: flex;
 		gap: 16px;
@@ -82,20 +87,24 @@
 <div class="stellarwp-telemetry-starter wrapper">
 	<section class="stellarwp-telemetry-starter modal">
 		<header>
-			<img src="<?php echo $args['url']; ?>" width="151" height="32" alt="Plugin Logo" />
-			<h1 class="stellarwp-telemetry-starter-header">We hope you love [The Events Calendar].</h1>
+			<img src="<?php echo $args['plugin_logo']; ?>" width="<?php echo $args['plugin_logo_width']; ?>" height="<?php echo $args['plugin_logo_height']; ?>" alt="<?php echo $args['plugin_logo_alt']; ?>" />
+			<h1 class="stellarwp-telemetry-starter-header">We hope you love <?php echo $args['plugin_name'] ; ?>.</h1>
 		</header>
 		<main>
-			<p>Hi, [username]! This is an invitation to help our StellarWP community. If you opt-in, some data about your usage of [The Events Calendar] and Future StellarWP Products will be shared with our teams (so they can work their butts off to improve). We will also share some helpful info on WordPress, and our products from time to time. And if you skip this, that’s okay! Our Products still works just fine.</p>
+			<p>Hi, <?php echo $args['user_name']; ?>! This is an invitation to help our StellarWP community.
+				If you opt-in, some data about your usage of <?php echo $args['plugin_name']; ?> and future
+				StellarWP Products will be shared with our teams (so they can work their butts off to improve).
+				We will also share some helpful info on WordPress, and our products from time to time.
+				And if you skip this, that’s okay! Our products still work just fine.</p>
 			<ul class="links">
-				<li><a href="#">What permissions are being granted?</a></li>
-				<li><a href="#">Terms of Service</a></li>
-				<li><a href="#">Privacy Policy</a></li>
+				<li><a href="<?php echo $args['permissions_url'] ;?>" target="_blank">What permissions are being granted?</a></li>
+				<li><a href="<?php echo $args['tos_url'] ;?>" target="_blank">Terms of Service</a></li>
+				<li><a href="<?php echo $args['privacy_url'] ;?>" target="_blank">Privacy Policy</a></li>
 			</ul>
 		</main>
 		<footer>
-			<button class="btn-primary">Allow &amp; Continue</button>
-			<button class="btn-text">Skip</button>
+			<a class="btn-primary" href="#">Allow &amp; Continue</a>
+			<a class="btn-text" href="#">Skip</a>
 		</footer>
 	</section>
 </div>

--- a/src/views/optin.php
+++ b/src/views/optin.php
@@ -1,0 +1,101 @@
+<?php
+// $args comes from load_template() in OptinTemplate.php
+/** @var array $args */
+?>
+<style>
+	.stellarwp-telemetry-starter.wrapper {
+		position: fixed;
+		bottom: 0;
+		right: 0;
+		width: 100%;
+		height: 100%;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 999999;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		transition: all -1.3s ease-in-out;
+	}
+
+	.stellarwp-telemetry-starter.modal {
+		position: absolute;
+		z-index: 999999;
+		display: flex;
+		flex-direction: column;
+		padding: 32px;
+		width: 90%;
+		top: 47px;
+		left: 32px;
+		background: #fff;
+		box-shadow: 0 0 32px rgba(0, 0, 0, 0.1);
+		border-radius: 4px;
+	}
+
+	.stellarwp-telemetry-starter h1 {
+		font-family: 'SF Pro Text', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+		font-size: 18px;
+		font-weight: 500;
+		line-height: 24px;
+		letter-spacing: -0.02em;
+		color: #000;
+	}
+
+	.stellarwp-telemetry-starter {
+		font-family: 'SF Pro Text', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+		font-size: 14px;
+		font-weight: 400;
+		line-height: 18px;
+		color: #4E4E4E;
+	}
+
+	.stellarwp-telemetry-starter .btn-primary,
+	.stellarwp-telemetry-starter .btn-text {
+		padding: 6px 12px;
+		background: #0047FF;
+		border-radius: 4px;
+		color: #fff;
+	}
+
+	.stellarwp-telemetry-starter .btn-text {
+		background: #fff;
+		color: #000;
+	}
+
+	.stellarwp-telemetry-starter .links {
+		display: flex;
+		gap: 16px;
+		font-size: 12px;
+		line-height: 16px;
+	}
+
+	.stellarwp-telemetry-starter .links a {
+		color: #0047FF;
+		text-decoration: none;
+	}
+</style>
+
+
+<script>
+	console.log('Hello World');
+</script>
+
+<div class="stellarwp-telemetry-starter wrapper">
+	<section class="stellarwp-telemetry-starter modal">
+		<header>
+			<img src="<?php echo $args['url']; ?>" width="151" height="32" alt="Plugin Logo" />
+			<h1 class="stellarwp-telemetry-starter-header">We hope you love [The Events Calendar].</h1>
+		</header>
+		<main>
+			<p>Hi, [username]! This is an invitation to help our StellarWP community. If you opt-in, some data about your usage of [The Events Calendar] and Future StellarWP Products will be shared with our teams (so they can work their butts off to improve). We will also share some helpful info on WordPress, and our products from time to time. And if you skip this, that’s okay! Our Products still works just fine.</p>
+			<ul class="links">
+				<li><a href="#">What permissions are being granted?</a></li>
+				<li><a href="#">Terms of Service</a></li>
+				<li><a href="#">Privacy Policy</a></li>
+			</ul>
+		</main>
+		<footer>
+			<button class="btn-primary">Allow &amp; Continue</button>
+			<button class="btn-text">Skip</button>
+		</footer>
+	</section>
+</div>


### PR DESCRIPTION
Modal now closes when clicking on Skip, and sends a GET param when agreeing so the implementing plugin can act.

This PR also removes the HTML code from the OptinTemplate class and moves it to its own views/optin.php template file, using $args passed from the load_template function.

