### PR TITLE
Require Opt-In Before Site Registration

### DIFF
--- a/src/Telemetry/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In_Subscriber.php
@@ -38,14 +38,30 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function set_optin_status() {
-		// If GET param is set, handle plugin actions.
-		if ( isset( $_GET['action'] ) && 'stellarwp-telemetry' === $_GET['action'] ) {
-			// If user opted in, register the site and don't show modal again.
-			if ( isset( $_GET['optin-agreed'] ) && 'true' === $_GET['optin-agreed'] ) {
-				$this->container->get( Opt_In_Status::class )->set_status( true );
-				update_option( $this->container->get( Opt_In_Status::class )->get_show_optin_option_name(), "0" );
-			}
+
+		// We're not attempting an action.
+		if ( empty( $_POST ) ) {
+			return;
 		}
+
+		// We're not attempting a telemetry action.
+		if ( $_POST['action'] !== 'stellarwp-telemetry' ) {
+			return;
+		}
+
+		// The user did not respond to the opt-in modal.
+		if ( ! isset( $_POST['optin-agreed'] ) ) {
+			return;
+		}
+
+		// User agreed to opt-in to Telemetry.
+		if ( 'true' === $_POST['optin-agreed'] ) {
+			$this->container->get( Telemetry::class )->register_site();
+			$this->container->get( Opt_In_Status::class )->set_status( true );
+		}
+
+		// Don't show the opt-in modal again.
+		update_option( $this->container->get( Opt_In_Status::class )->get_show_optin_option_name(), "0" );
 	}
 
 	/**

--- a/src/views/optin.php
+++ b/src/views/optin.php
@@ -88,23 +88,6 @@
 	}
 </style>
 
-
-<script>
-	// JS document on ready event
-	document.addEventListener("DOMContentLoaded", function () {
-		let wrapper = document.getElementById("modal-wrapper");
-
-		document.getElementById("close-modal").addEventListener("click", function (event) {
-			event.preventDefault();
-			close_modal(wrapper);
-		});
-	});
-
-	function close_modal(wrapper) {
-		wrapper.parentNode.removeChild(wrapper);
-	}
-</script>
-
 <div id="modal-wrapper" class="stellarwp-telemetry wrapper">
 	<section class="stellarwp-telemetry modal">
 		<header>

--- a/src/views/optin.php
+++ b/src/views/optin.php
@@ -126,11 +126,11 @@
 			</ul>
 		</main>
 		<footer>
-			<form method="get">
+			<form method="post" action="">
 				<input type="hidden" name="page" value="<?php echo esc_attr( $_GET['page'] ); ?>">
 				<input type="hidden" name="action" value="stellarwp-telemetry">
 				<button id="agree-modal" class="btn-primary" type="submit" name="optin-agreed" value="true">Allow &amp; Continue</button>
-				<button id="close-modal" class="btn-text" type="button">Skip</button>
+				<button id="close-modal" class="btn-text" type="submit" name="optin-agreed" value="false">Skip</button>
 			</form>
 		</footer>
 	</section>


### PR DESCRIPTION
This fixes a bug where the site data would be sent to the Telemetry server as soon as it loaded without the user being opted in. Instead, we register the site as soon as the user agrees with the opt-in modal.