### PR TITLE
Add Server URL Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,23 @@ A library for Opt-in and Telemetry data to be sent to the StellarWP Telemetry se
 		- [Prompting Users on a Settings Page](#prompting-users-on-a-settings-page)
 	- [Server Authentication Flow](#server-authentication-flow)
 	- [Filter Reference](#filter-reference)
-		- [stellarwp/telemetry/should_show_optin](#stellarwptelemetryshould_show_optin)
-		- [stellarwp/telemetry/show_optin_option_name](#stellarwptelemetryshow_optin_option_name)
-		- [stellarwp/telemetry/cron_interval](#stellarwptelemetrycron_interval)
-		- [stellarwp/telemetry/cron_hook_name](#stellarwptelemetrycron_hook_name)
+		- [stellarwp/telemetry/should\_show\_optin](#stellarwptelemetryshould_show_optin)
+		- [stellarwp/telemetry/show\_optin\_option\_name](#stellarwptelemetryshow_optin_option_name)
+		- [stellarwp/telemetry/cron\_interval](#stellarwptelemetrycron_interval)
+		- [stellarwp/telemetry/cron\_hook\_name](#stellarwptelemetrycron_hook_name)
 		- [stellarwp/telemetry/data](#stellarwptelemetrydata)
-		- [stellarwp/telemetry/option_name](#stellarwptelemetryoption_name)
-		- [stellarwp/telemetry/optin_status](#stellarwptelemetryoptin_status)
-		- [stellarwp/telemetry/optin_status_label](#stellarwptelemetryoptin_status_label)
-		- [stellarwp/telemetry/optin_args](#stellarwptelemetryoptin_args)
-		- [stellarwp/telemetry/show_optin_option_name](#stellarwptelemetryshow_optin_option_name-1)
-		- [stellarwp/telemetry/register_site_url](#stellarwptelemetryregister_site_url)
-		- [stellarwp/telemetry/register_site_data](#stellarwptelemetryregister_site_data)
-		- [stellarwp/telemetry/register_site_user_details](#stellarwptelemetryregister_site_user_details)
-		- [stellarwp/telemetry/send_data_args](#stellarwptelemetrysend_data_args)
-		- [stellarwp/telemetry/send_data_url](#stellarwptelemetrysend_data_url)
+		- [stellarwp/telemetry/option\_name](#stellarwptelemetryoption_name)
+		- [stellarwp/telemetry/optin\_status](#stellarwptelemetryoptin_status)
+		- [stellarwp/telemetry/optin\_status\_label](#stellarwptelemetryoptin_status_label)
+		- [stellarwp/telemetry/optin\_args](#stellarwptelemetryoptin_args)
+		- [stellarwp/telemetry/show\_optin\_option\_name](#stellarwptelemetryshow_optin_option_name-1)
+		- [stellarwp/telemetry/register\_site\_url](#stellarwptelemetryregister_site_url)
+		- [stellarwp/telemetry/register\_site\_data](#stellarwptelemetryregister_site_data)
+		- [stellarwp/telemetry/register\_site\_user\_details](#stellarwptelemetryregister_site_user_details)
+		- [stellarwp/telemetry/send\_data\_args](#stellarwptelemetrysend_data_args)
+		- [stellarwp/telemetry/send\_data\_url](#stellarwptelemetrysend_data_url)
 		- [stellarwp/telemetry/token](#stellarwptelemetrytoken)
-		- [stellarwp/telemetry/exit_interview_args](#stellarwptelemetryexit_interview_args)
+		- [stellarwp/telemetry/exit\_interview\_args](#stellarwptelemetryexit_interview_args)
 ## Installation
 
 It's recommended that you install Telemetry as a project dependency via [Composer](https://getcomposer.org/):
@@ -68,6 +68,9 @@ function initialize_telemetry() {
 	 */
 	$container = new Container();
 	Config::set_container( $container );
+
+	// Set the full URL for the Telemetry Server API.
+	Config::set_server_url( 'https://telemetry.example.com/api/v1' );
 
 	// Optional: Set a unique prefix for actions & filters.
 	Config::set_hook_prefix( 'my-custom-prefix' );

--- a/src/Telemetry/Config.php
+++ b/src/Telemetry/Config.php
@@ -44,7 +44,7 @@ class Config {
 	 *
 	 * @var string
 	 */
-	protected static $server_url = '';
+	protected static $server_url = 'https://telemetry.stellarwp.com/api/v1';
 
 	/**
 	 * Get the container.
@@ -105,7 +105,7 @@ class Config {
 	 */
 	public static function reset() {
 		static::$hook_prefix = '';
-		static::$server_url  = '';
+		static::$server_url  = 'https://telemetry.stellarwp.com/api/v1';
 	}
 
 	/**

--- a/src/Telemetry/Config.php
+++ b/src/Telemetry/Config.php
@@ -38,6 +38,15 @@ class Config {
 	protected static $hook_prefix = '';
 
 	/**
+	 * The url of the telemetry server.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	protected static $server_url = '';
+
+	/**
 	 * Get the container.
 	 *
 	 * @since 1.0.0
@@ -66,6 +75,17 @@ class Config {
 	}
 
 	/**
+	 * Gets the telemetry server url.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public static function get_server_url() {
+		return static::$server_url;
+	}
+
+	/**
 	 * Returns whether the container has been set.
 	 *
 	 * @since 1.0.0
@@ -85,6 +105,7 @@ class Config {
 	 */
 	public static function reset() {
 		static::$hook_prefix = '';
+		static::$server_url  = '';
 	}
 
 	/**
@@ -116,6 +137,19 @@ class Config {
 		}
 
 		static::$hook_prefix = $prefix;
+	}
+
+	/**
+	 * Sets the telemetry server url.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $url
+	 *
+	 * @return void
+	 */
+	public static function set_server_url( string $url ) {
+		static::$server_url = $url;
 	}
 
 }

--- a/src/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry.php
@@ -18,8 +18,6 @@ use StellarWP\Telemetry\Contracts\Data_Provider;
  * @package StellarWP\Telemetry
  */
 class Telemetry {
-	public const SERVER_URL = 'https://telemetry-api.moderntribe.qa/api/v1';
-
 	/**
 	 * A data provider for gathering the data.
 	 *
@@ -170,7 +168,7 @@ class Telemetry {
 		 *
 		 * @param string $site_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_url', self::SERVER_URL . '/register-site' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_url', Config::get_server_url() . '/register-site' );
 	}
 
 	/**
@@ -188,7 +186,7 @@ class Telemetry {
 		 *
 		 * @param string $uninstall_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'uninstall_url', self::SERVER_URL . '/uninstall' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'uninstall_url', Config::get_server_url() . '/uninstall' );
 	}
 
 	/**
@@ -323,7 +321,7 @@ class Telemetry {
 		 *
 		 * @param string $data_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'send_data_url', self::SERVER_URL . '/telemetry' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'send_data_url', Config::get_server_url() . '/telemetry' );
 	}
 
 	/**


### PR DESCRIPTION
This adds a new config option for defining the Telemetry Server URL so plugins aren't locked in to any single server instance. It also removes places where we were statically defining a URL.