### PR TITLE
Bugfix: Updates is_expired to use a more reliable date diff

### DIFF
--- a/src/Telemetry/Last_Send.php
+++ b/src/Telemetry/Last_Send.php
@@ -52,20 +52,18 @@ class Last_Send {
 			return true;
 		}
 
-		$timestamp   = new DateTimeImmutable( $last_send );
-		$now         = new DateTimeImmutable();
-		$interval    = date_diff( $timestamp, $now );
-
 		/**
 		 * Filters the amount of seconds the last send timestamp is valid before it expires.
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param integer $expire_days
+		 * @param integer $expire_seconds
 		 */
-		$expire_days = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'last_send_expire_seconds', 7 * DAY_IN_SECONDS );
+		$expire_seconds = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'last_send_expire_seconds', 7 * DAY_IN_SECONDS );
 
-		return $interval->s >= $expire_days;
+		$last_run_time = new DateTimeImmutable( $last_send );
+		$next_run_time = $last_run_time->add( new \DateInterval("PT{$expire_seconds}S") );
+		return $next_run_time <= new DateTimeImmutable();
 	}
 
 	/**


### PR DESCRIPTION
The `DateTimeInterface::diff()->s` property only goes up to 60 before adding one to the minute property and resetting back to 0.  This update adds the seconds to the last ran date creating a next run date, and compares the value to now. 