### PR TITLE
[FRAME-100] Uninstall Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A library for Opt-in and Telemetry data to be sent to the StellarWP Telemetry se
 	- [Installation](#installation)
 	- [Usage Prerequisites](#usage-prerequisites)
 	- [Integration](#integration)
+	- [Uninstall Hook](#uninstall-hook)
 	- [Opt-In Modal Usage](#opt-in-modal-usage)
 		- [Prompting Users on a Settings Page](#prompting-users-on-a-settings-page)
 	- [Server Authentication Flow](#server-authentication-flow)
@@ -95,6 +96,20 @@ function initialize_telemetry() {
 ```
 
 Using a custom hook prefix provides the ability to uniquely filter functionality of your plugin's specific instance of the library.
+
+## Uninstall Hook
+
+This library provides everything necessary to uninstall itself. Depending on when your plugin uninstalls itself and cleans up the database, you can include this static method to have the library purge the options table of the necessary rows:
+```php
+<?php// uninstall.php
+
+use YOUR_STRAUSS_PREFIX\StellarWP\Telemetry\Uninstall;
+
+require_once 'vendor/strauss/autoload.php';
+
+Uninstall::run( 'your-plugin-slug' );
+```
+When a user deletes the plugin, WordPress runs the method from `Uninstall` and cleans up the options table. The last plugin utilizing the library will remove all options.
 
 ## Opt-In Modal Usage
 

--- a/src/Telemetry/Opt_In_Status.php
+++ b/src/Telemetry/Opt_In_Status.php
@@ -150,6 +150,28 @@ class Opt_In_Status {
 	}
 
 	/**
+	 * Removes a plugin slug from the opt-in option array.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string  $plugin_slug The slug to remove from the option.
+	 *
+	 * @return boolean
+	 */
+	public function remove_plugin( string $plugin_slug ) {
+		$option = $this->get_option();
+
+		// Bail early if the slug does not exist in the option.
+		if ( ! isset( $option[ $plugin_slug ] ) ) {
+			return false;
+		}
+
+		unset( $option[ $plugin_slug ] );
+
+		return update_option( $this->get_option_name(), $option );
+	}
+
+	/**
 	 * Get an array of opted-in plugins.
 	 *
 	 * @since 1.0.0

--- a/src/Telemetry/Uninstall.php
+++ b/src/Telemetry/Uninstall.php
@@ -56,6 +56,7 @@ class Uninstall {
 		// All plugins have been removed, the token should be the only item in the array.
 		if ( array_key_exists( 'token', $optin ) ) {
 			delete_option( 'stellarwp_telemetry' );
+			delete_option( 'stellarwp_telemetry_last_send' );
 		}
 	}
 }

--- a/src/Telemetry/Uninstall.php
+++ b/src/Telemetry/Uninstall.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Registers methods used for uninstalling the current instance of the library.
+ *
+ * @since 1.0.0
+ *
+ * @package StellarWP\Telemetry
+ */
+
+namespace StellarWP\Telemetry;
+
+/**
+ * Uninstall class used for uninstalling the current instance of the library.
+ *
+ * @since 1.0.0
+ *
+ * @package StellarWP\Telemetry
+ */
+class Uninstall {
+
+	/**
+	 * Removes necessary items from the options table.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $plugin_slug
+	 *
+	 * @return void
+	 */
+	public static function run( string $plugin_slug ) {
+		require_once dirname( __FILE__ ) . '/Opt_In_Status.php';
+		$opt_in_status = new Opt_In_Status();
+
+		if ( $opt_in_status->plugin_exists( $plugin_slug ) ) {
+			$opt_in_status->remove_plugin( $plugin_slug );
+		}
+
+		$optin_option_name = 'stellarwp_telemetry_' . $plugin_slug . '_show_optin';
+
+		if ( get_option( $optin_option_name ) !== false ) {
+			delete_option( $optin_option_name );
+		}
+
+		// If this is the last plugin in the optin option, let's remove the option entirely.
+		self::maybe_remove_optin_option();
+	}
+
+	public static function maybe_remove_optin_option() {
+		$optin = get_option( 'stellarwp_telemetry' );
+
+		// Bail if option has more than 'token' in the array.
+		if ( count( $optin ) > 1 ) {
+			return;
+		}
+
+		// All plugins have been removed, the token should be the only item in the array.
+		if ( array_key_exists( 'token', $optin ) ) {
+			delete_option( 'stellarwp_telemetry' );
+		}
+	}
+}


### PR DESCRIPTION
This includes the necessary methods & documentation for plugins to have the library uninstall itself and remove the necessary options from the database.

Each plugin removes it's specific options from the table. Only the last plugin that uninstalls itself will remove all options completely.