### PR TITLE
Update Opt-In data to send what server expects

### DIFF
--- a/src/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry.php
@@ -246,11 +246,13 @@ class Telemetry {
 		 *
 		 * @param array $site_user_details
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_user_details', [
+		$user_info = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_user_details', [
 			'name'  => $user->display_name,
 			'email' => $user->user_email,
 			'plugin_slug' => Config::get_container()->get( Core::PLUGIN_SLUG ),
 		] );
+
+		return [ 'user' => wp_json_encode( $user_info ) ];
 	}
 
 	/**


### PR DESCRIPTION
The telemetry server was throwing a method exception when the user data was POSTed to the server. This json_encodes the data and sends it how the server expects it.