### PR TITLE
Prevent request from trying to verify ssl cert

### DIFF
--- a/src/Telemetry/Telemetry/Telemetry_Subscriber.php
+++ b/src/Telemetry/Telemetry/Telemetry_Subscriber.php
@@ -68,9 +68,9 @@ class Telemetry_Subscriber extends Abstract_Subscriber {
 		wp_remote_post(
 			$url,
 			[
-				'blocking' => false,
-				'timeout'  => 1,
-				'body'     => [
+				'blocking'  => false,
+				'sslverify' => false,
+				'body'      => [
 					'action' => Telemetry::AJAX_ACTION,
 				],
 			]


### PR DESCRIPTION
We noticed that sometimes the ajax request during the 'shutdown' action would fail and prevented the Telemetry data from being sent to the Telemetry server. After digging in some, we realized that it was failing due to an invalid cert and from [the WordPress codex](https://developer.wordpress.org/reference/classes/WP_Http/request/#parameters), I found that you can include `'sslverify' => false` to prevent the request from trying to validate the certificate.

Before adding that parameter, the request failed unexpectedly on my local machine that I was able to replicate the error we were seeing on a Nexcess server. Adding the parameter allowed the request to continue and telemetry data was successfully sent to the server.

This should resolve occasional issues on environments where an invalid cert or self-signed certificate exists.