### PR TITLE
Make method public to avoid get_option cache

### DIFF
--- a/src/Telemetry/Last_Send/Last_Send.php
+++ b/src/Telemetry/Last_Send/Last_Send.php
@@ -114,7 +114,7 @@ class Last_Send {
 	 *
 	 * @return string The timestamp of the last send.
 	 */
-	private function get_timestamp() {
+	public function get_timestamp() {
 		global $wpdb;
 
 		$result = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching


### PR DESCRIPTION
Sometimes when the timestamp is retrieved, it's the cached value and not the actual value in the database. By making this method public, it can be used elsewhere.