### PR TITLE
Adds Config::stellar_slug

### DIFF
--- a/src/Telemetry/Config.php
+++ b/src/Telemetry/Config.php
@@ -172,11 +172,6 @@ class Config {
 	 * @return void
 	 */
 	public static function set_stellar_slug( string $stellar_slug ) {
-		// Make sure the prefix always ends with a separator.
-		if ( substr( $stellar_slug, -1 ) !== '/' ) {
-			$stellar_slug = $stellar_slug . '/';
-		}
-
 		static::$stellar_slug = $stellar_slug;
 	}
 

--- a/src/Telemetry/Config.php
+++ b/src/Telemetry/Config.php
@@ -39,6 +39,15 @@ class Config {
 	protected static $hook_prefix = '';
 
 	/**
+	 * Unique ID for the stellarwp slug.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	protected static $stellar_slug = '';
+
+	/**
 	 * The url of the telemetry server.
 	 *
 	 * @since 1.0.0
@@ -87,6 +96,17 @@ class Config {
 	}
 
 	/**
+	 * Gets the stellar slug server url.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public static function get_stellar_slug() {
+		return static::$stellar_slug;
+	}
+
+	/**
 	 * Returns whether the container has been set.
 	 *
 	 * @since 1.0.0
@@ -105,8 +125,9 @@ class Config {
 	 * @return void
 	 */
 	public static function reset() {
-		static::$hook_prefix = '';
-		static::$server_url  = 'https://telemetry.stellarwp.com/api/v1';
+		static::$hook_prefix  = '';
+		static::$server_url   = 'https://telemetry.stellarwp.com/api/v1';
+		static::$stellar_slug = '';
 	}
 
 	/**
@@ -138,6 +159,25 @@ class Config {
 		}
 
 		static::$hook_prefix = $prefix;
+	}
+
+
+	/**
+	 * Sets the stellar slug.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $stellar_slug The unique slug to identify the plugin with the server.
+	 *
+	 * @return void
+	 */
+	public static function set_stellar_slug( string $stellar_slug ) {
+		// Make sure the prefix always ends with a separator.
+		if ( substr( $stellar_slug, -1 ) !== '/' ) {
+			$stellar_slug = $stellar_slug . '/';
+		}
+
+		static::$stellar_slug = $stellar_slug;
 	}
 
 	/**

--- a/src/Telemetry/Core.php
+++ b/src/Telemetry/Core.php
@@ -31,7 +31,6 @@ use StellarWP\Telemetry\Telemetry\Telemetry_Subscriber;
  * @package StellarWP\Telemetry
  */
 class Core {
-	public const PLUGIN_SLUG     = 'plugin.slug';
 	public const PLUGIN_BASENAME = 'plugin.basename';
 
 	/**
@@ -113,17 +112,6 @@ class Core {
 	}
 
 	/**
-	 * Gets the plugin's slug.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string
-	 */
-	public function get_plugin_slug() {
-		return $this->container->get( self::PLUGIN_SLUG );
-	}
-
-	/**
 	 * Initializes the container with library resources.
 	 *
 	 * @since 1.0.0
@@ -135,7 +123,6 @@ class Core {
 	private function init_container( string $plugin_path ): void {
 		$container = Config::get_container();
 
-		$container->bind( self::PLUGIN_SLUG, dirname( plugin_basename( $plugin_path ) ) );
 		$container->bind( self::PLUGIN_BASENAME, plugin_basename( $plugin_path ) );
 		$container->bind( Data_Provider::class, Debug_Data::class );
 		$container->bind(

--- a/src/Telemetry/Exit_Interview/Exit_Interview_Subscriber.php
+++ b/src/Telemetry/Exit_Interview/Exit_Interview_Subscriber.php
@@ -11,6 +11,7 @@ namespace StellarWP\Telemetry\Exit_Interview;
 
 use StellarWP\Telemetry\Contracts\Abstract_Subscriber;
 use StellarWP\Telemetry\Config;
+use StellarWP\Telemetry\Core;
 use StellarWP\Telemetry\Telemetry\Telemetry;
 
 /**

--- a/src/Telemetry/Exit_Interview/Exit_Interview_Subscriber.php
+++ b/src/Telemetry/Exit_Interview/Exit_Interview_Subscriber.php
@@ -10,7 +10,7 @@
 namespace StellarWP\Telemetry\Exit_Interview;
 
 use StellarWP\Telemetry\Contracts\Abstract_Subscriber;
-use StellarWP\Telemetry\Core;
+use StellarWP\Telemetry\Config;
 use StellarWP\Telemetry\Telemetry\Telemetry;
 
 /**
@@ -124,7 +124,7 @@ class Exit_Interview_Subscriber extends Abstract_Subscriber {
 		}
 
 		if ( ! empty( $deactivate_link ) ) {
-			$deactivate_link .= '<i class="telemetry-plugin-slug" data-plugin-slug="' . $this->container->get( Core::PLUGIN_SLUG ) . '"></i>';
+			$deactivate_link .= '<i class="telemetry-plugin-slug" data-plugin-slug="' . Config::get_stellar_slug() . '"></i>';
 
 			// Append deactivation link.
 			$before_deactivate['deactivate'] = $deactivate_link;

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -62,7 +62,7 @@ class Template implements Template_Interface {
 		return apply_filters(
 			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'exit_interview_args',
 			[
-				'plugin_slug'        => $this->container->get( Core::PLUGIN_SLUG ),
+				'plugin_slug'        => Config::get_stellar_slug(),
 				'plugin_logo'        => Resources::get_asset_path() . 'resources/images/stellar-logo.svg',
 				'plugin_logo_width'  => 151,
 				'plugin_logo_height' => 32,

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -95,7 +95,7 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function initialize_optin_option() {
-		$plugin_slug     = $this->container->get( Core::PLUGIN_SLUG );
+		$plugin_slug     = Config::get_stellar_slug();
 		$opt_in_template = $this->container->get( Opt_In_Template::class );
 		$opt_in_status   = $this->container->get( Status::class );
 

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -67,7 +67,7 @@ class Opt_In_Template implements Template_Interface {
 			'plugin_logo_height'    => 32,
 			'plugin_logo_alt'       => 'StellarWP Logo',
 			'plugin_name'           => 'StellarWP',
-			'plugin_slug'           => Config::get_container()->get( Core::PLUGIN_SLUG ),
+			'plugin_slug'           => Config::get_stellar_slug(),
 			'user_name'             => wp_get_current_user()->display_name,
 			'permissions_url'       => '#',
 			'tos_url'               => '#',
@@ -130,8 +130,6 @@ class Opt_In_Template implements Template_Interface {
 	 * @return string
 	 */
 	public function get_option_name() {
-		$plugin_slug = Config::get_container()->get( Core::PLUGIN_SLUG );
-
 		/**
 		 * Filters if the Opt-In modal should be rendered.
 		 *
@@ -141,7 +139,7 @@ class Opt_In_Template implements Template_Interface {
 		 */
 		return apply_filters(
 			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'show_optin_option_name',
-			'stellarwp_telemetry_' . $plugin_slug . '_show_optin'
+			'stellarwp_telemetry_' . Config::get_stellar_slug() . '_show_optin'
 		);
 	}
 

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -327,7 +327,7 @@ class Telemetry {
 			return false;
 		}
 
-		if (! $this->opt_in_status->is_active() ) {
+		if ( ! $this->opt_in_status->is_active() ) {
 			return false;
 		}
 

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -327,7 +327,7 @@ class Telemetry {
 			return false;
 		}
 
-		if (! $this->status->is_active() ) {
+		if (! $this->opt_in_status->is_active() ) {
 			return false;
 		}
 
@@ -349,7 +349,7 @@ class Telemetry {
 			[
 				'token'     => $this->get_token(),
 				'telemetry' => wp_json_encode( $this->provider->get_data() ),
-				'stellar_slugs' => wp_json_encode( $this->status->get_opted_in_plugins() ),
+				'stellar_slugs' => wp_json_encode( $this->opt_in_status->get_opted_in_plugins() ),
 			]
 		);
 	}

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -327,6 +327,10 @@ class Telemetry {
 			return false;
 		}
 
+		if (! $this->status->is_active() ) {
+			return false;
+		}
+
 		$response = $this->send( $this->get_send_data_args(), $this->get_send_data_url() );
 
 		return $response['status'] ?? false;
@@ -345,6 +349,7 @@ class Telemetry {
 			[
 				'token'     => $this->get_token(),
 				'telemetry' => wp_json_encode( $this->provider->get_data() ),
+				'stellar_slugs' => wp_json_encode( $this->status->get_opted_in_plugins() ),
 			]
 		);
 	}

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -347,8 +347,8 @@ class Telemetry {
 		return apply_filters(
 			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'send_data_args',
 			[
-				'token'     => $this->get_token(),
-				'telemetry' => wp_json_encode( $this->provider->get_data() ),
+				'token'         => $this->get_token(),
+				'telemetry'     => wp_json_encode( $this->provider->get_data() ),
 				'stellar_slugs' => wp_json_encode( $this->opt_in_status->get_opted_in_plugins() ),
 			]
 		);

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -263,7 +263,7 @@ class Telemetry {
 			[
 				'name'        => $user->display_name,
 				'email'       => $user->user_email,
-				'plugin_slug' => Config::get_container()->get( Core::PLUGIN_SLUG ),
+				'plugin_slug' => Config::get_stellar_slug(),
 			]
 		);
 

--- a/src/Telemetry/Uninstall.php
+++ b/src/Telemetry/Uninstall.php
@@ -25,18 +25,18 @@ class Uninstall {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $plugin_slug The slug for the plugin being deleted.
+	 * @param string $stellar_slug The slug for the plugin being deleted.
 	 *
 	 * @return void
 	 */
-	public static function run( string $plugin_slug ) {
+	public static function run( string $stellar_slug ) {
 		$opt_in_status = new Status();
 
-		if ( $opt_in_status->plugin_exists( $plugin_slug ) ) {
-			$opt_in_status->remove_plugin( $plugin_slug );
+		if ( $opt_in_status->plugin_exists( $stellar_slug ) ) {
+			$opt_in_status->remove_plugin( $stellar_slug );
 		}
 
-		$optin_option_name = 'stellarwp_telemetry_' . $plugin_slug . '_show_optin';
+		$optin_option_name = 'stellarwp_telemetry_' . $stellar_slug . '_show_optin';
 
 		if ( get_option( $optin_option_name ) !== false ) {
 			delete_option( $optin_option_name );

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -27,4 +27,13 @@ class ConfigTest extends WPTestCase {
 
 		Config::get_container();
 	}
+
+	public function test_it_should_set_stellar_slug() {
+		Config::set_stellar_slug( 'unique_slug' );
+		$this->assertEquals( 'unique_slug/', Config::get_stellar_slug() );
+
+		//Doesn't add trailing slash if it already exists
+		Config::set_stellar_slug( 'unique_slug_with_slash/' );
+		$this->assertEquals( 'unique_slug_with_slash/', Config::get_stellar_slug() );
+	}
 }

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -30,10 +30,7 @@ class ConfigTest extends WPTestCase {
 
 	public function test_it_should_set_stellar_slug() {
 		Config::set_stellar_slug( 'unique_slug' );
-		$this->assertEquals( 'unique_slug/', Config::get_stellar_slug() );
 
-		//Doesn't add trailing slash if it already exists
-		Config::set_stellar_slug( 'unique_slug_with_slash/' );
-		$this->assertEquals( 'unique_slug_with_slash/', Config::get_stellar_slug() );
+		$this->assertEquals( 'unique_slug', Config::get_stellar_slug() );
 	}
 }


### PR DESCRIPTION
Adds `Config::set_stellar_slug( $unique_plugin_slug )`
Adds `Config::get_stellar_slug() : string`
Updates telemetry send to check the is_active status from the status class.
Adds slugs to the telemetry send.