### PR TITLE
Only run jobs when specific files have changed

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - 'src/**/*.php'
 
 jobs:
   php-compatibility:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -17,8 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Detect File Changes
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          list-files: shell
+          filters: |
+            src:
+              - added|modified: 'src/**/*.php'
+
       - name: Configure PHP environment
         uses: shivammathur/setup-php@v2
+        if: ${{ steps.filter.outputs.src == 'true' }}
         with:
           php-version: 7.4
           extensions: mbstring, intl
@@ -29,14 +39,17 @@ jobs:
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
+        if: ${{ steps.filter.outputs.src == 'true' }}
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
       - uses: ramsey/composer-install@v2
+        if: ${{ steps.filter.outputs.src == 'true' }}
         with:
           dependency-versions: highest
 
       - name: Run PHP Compatibility
-        run: composer compatibility:php-${{ matrix.php-version }}
+        if: ${{ steps.filter.outputs.src == 'true' }}
+        run: phpcs ${{ steps.filter.outputs.wpcontent_files }} -s --standard=PHPCompatibilityWP --runtime-set testVersion ${{ matrix.php-version }}

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -19,18 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Detect File Changes
-        uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          list-files: shell
-          filters: |
-            src:
-              - added|modified: 'src/**/*.php'
-
       - name: Configure PHP environment
         uses: shivammathur/setup-php@v2
-        if: ${{ steps.filter.outputs.src == 'true' }}
         with:
           php-version: 7.4
           extensions: mbstring, intl
@@ -40,18 +30,17 @@ jobs:
         id: composer-cache
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
       - uses: actions/cache@v3
-        if: ${{ steps.filter.outputs.src == 'true' }}
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
+
       - uses: ramsey/composer-install@v2
-        if: ${{ steps.filter.outputs.src == 'true' }}
         with:
           dependency-versions: highest
 
       - name: Run PHP Compatibility
-        if: ${{ steps.filter.outputs.src == 'true' }}
         run: phpcs ${{ steps.filter.outputs.wpcontent_files }} -s --standard=PHPCompatibilityWP --runtime-set testVersion ${{ matrix.php-version }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,6 +1,9 @@
 name: Coding Standards
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'src/**/*.php'
 
 jobs:
   phpcs:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,6 +1,9 @@
 name: Static Analysis
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'src/**/*.php'
 
 jobs:
   phpstan:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: 'Tests'
 on:
   push:
+  pull_request:
+    paths:
+      - 'src/**/*.php'
+      - 'tests/**/*.php'
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: 'Tests'
 on:
   push:
+    paths:
+      - 'src/**/*.php'
+      - 'tests/**/*.php'
   pull_request:
     paths:
       - 'src/**/*.php'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,8 @@
 name: 'Tests'
 on:
   push:
-    paths:
-      - 'src/**/*.php'
-      - 'tests/**/*.php'
+    branches:
+      - 'main'
   pull_request:
     paths:
       - 'src/**/*.php'

--- a/src/Telemetry/Core.php
+++ b/src/Telemetry/Core.php
@@ -5,8 +5,6 @@
  * @since 1.0.0
  *
  * @package StellarWP\Telemetry
- *
- * test
  */
 
 namespace StellarWP\Telemetry;

--- a/src/Telemetry/Core.php
+++ b/src/Telemetry/Core.php
@@ -5,6 +5,8 @@
  * @since 1.0.0
  *
  * @package StellarWP\Telemetry
+ *
+ * test
  */
 
 namespace StellarWP\Telemetry;


### PR DESCRIPTION
Right now, these jobs run for all files. To improve efficiency, they only need to run with the specific set of added/changed files.