### PR TITLE
Initialize options on init instead of admin_init

### DIFF
--- a/src/Telemetry/Last_Send/Last_Send_Subscriber.php
+++ b/src/Telemetry/Last_Send/Last_Send_Subscriber.php
@@ -28,7 +28,7 @@ class Last_Send_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function register() {
-		add_action( 'admin_init', [ $this, 'initialize_last_send_option' ] );
+		add_action( 'init', [ $this, 'initialize_last_send_option' ] );
 	}
 
 	/**

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -31,7 +31,7 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	public function register(): void {
 		add_action( 'stellarwp/telemetry/' . Config::get_stellar_slug() . '/optin', [ $this, 'maybe_render_optin' ] );
 		add_action( 'admin_init', [ $this, 'set_optin_status' ] );
-		add_action( 'admin_init', [ $this, 'initialize_optin_option' ] );
+		add_action( 'init', [ $this, 'initialize_optin_option' ] );
 	}
 
 	/**

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -11,7 +11,6 @@ namespace StellarWP\Telemetry\Opt_In;
 
 use StellarWP\Telemetry\Config;
 use StellarWP\Telemetry\Contracts\Abstract_Subscriber;
-use StellarWP\Telemetry\Core;
 use StellarWP\Telemetry\Telemetry\Telemetry;
 
 /**


### PR DESCRIPTION
The options need to be set any time the plugin is active because the plugin tries to send telemetry data on shutdown. Therefore the options need to exist before that method is called. Also, the plugin could be activated outside of the `admin_init`—using WP CLI or a MU plugin that automatically activates plugins.

Closes #51 