### PR TITLE
Add stellar_slugs to the register site request

### DIFF
--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -236,7 +236,8 @@ class Telemetry {
 		return apply_filters(
 			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_data',
 			[
-				'telemetry' => wp_json_encode( $this->provider->get_data() ),
+				'telemetry'     => wp_json_encode( $this->provider->get_data() ),
+				'stellar_slugs' => wp_json_encode( $this->opt_in_status->get_opted_in_plugins() ),
 			]
 		);
 	}


### PR DESCRIPTION
This adds the opted-in plugin slugs so the telemetry data can be linked with the correct brands on the server.