### PR TITLE
Avoid recommending strauss_overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,24 +41,6 @@ composer require stellarwp/telemetry
 >
 > Luckily, adding Strauss to your `composer.json` is only slightly more complicated than adding a typical dependency, so checkout our [strauss docs](https://github.com/stellarwp/global-docs/blob/main/docs/strauss-setup.md).
 
-*Note: When including this with Strauss, additional directories need to be copied. Add the following to your Strauss config:*
-```
-"extra": {
-  "strauss": {
-	[...]
-    "override_autoload": {
-      "stellarwp/telemetry": {
-        "files": [
-          "src/views",
-          "src/resources",
-          "src/Telemetry"
-        ]
-      }
-    }
-  }
-}
-```
-
 ## Usage Prerequisites
 To actually _use_ the telemetry library, you must have a Dependency Injection Container (DI Container) that is compatible with [di52](https://github.com/lucatume/di52) (_We recommend using di52_).
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,9 @@
   },
   "autoload": {
     "psr-4": {
-      "StellarWP\\Telemetry\\": "src/Telemetry"
+      "StellarWP\\Telemetry\\": "src/Telemetry",
+      "StellarWP\\Telemetry\\Views_Dir\\": "src/views",
+      "StellarWP\\Telemetry\\Assets_Dir\\": "src/resources"
     }
   },
   "autoload-dev": {


### PR DESCRIPTION
The strauss_overload messes with the namespace overrides that Strauss is meant to perform. Instead, to force Strauss to copy/address directories, you can set up fake namespaces for PSR-4 autoloading and that causes Strauss to properly copy the files. In this library's case, it copies `src/Telemetry`, `src/views`, and `src/resources`.