### PR TITLE
[FRAME-125] Exit Interviews Deactivate Button Disabling All Options

### DIFF
--- a/src/resources/js/scripts.js
+++ b/src/resources/js/scripts.js
@@ -80,6 +80,7 @@
 
 				if ( ! $reason.length ) {
 					$exitInterview.find('.stellarwp-telemetry-error-message').show();
+					this.disabled = false;
 					return;
 				}
 
@@ -92,6 +93,7 @@
 				if ( $comment.length ) {
 					if ( ! $comment.val() ) {
 						$exitInterview.find('.stellarwp-telemetry-error-message').show();
+						this.disabled = false;
 						return;
 					}
 


### PR DESCRIPTION
The deactivate button needs re-activating if the form contains errors.