### PR TITLE
Bug: Check variable before using it.

### DIFF
--- a/src/views/optin.php
+++ b/src/views/optin.php
@@ -54,7 +54,6 @@
 		</main>
 		<footer>
 			<form method="post" action="" data-js="optin-form">
-				<input type="hidden" name="page" value="<?php echo esc_attr( isset( $_GET['page'] ) ? $_GET['page'] : '' ); // phpcs:ignore WordPress.Security ?>">
 				<input type="hidden" name="action" value="stellarwp-telemetry">
 				<?php wp_nonce_field( 'stellarwp-telemetry' ); ?>
 				<button class="stellarwp-telemetry-btn-primary" data-js="form-submit" type="submit" name="optin-agreed" value="true">

--- a/src/views/optin.php
+++ b/src/views/optin.php
@@ -54,7 +54,7 @@
 		</main>
 		<footer>
 			<form method="post" action="" data-js="optin-form">
-				<input type="hidden" name="page" value="<?php echo esc_attr( issest( $_GET['page'] ) ? $_GET['page'] : '' ); // phpcs:ignore WordPress.Security ?>">
+				<input type="hidden" name="page" value="<?php echo esc_attr( isset( $_GET['page'] ) ? $_GET['page'] : '' ); // phpcs:ignore WordPress.Security ?>">
 				<input type="hidden" name="action" value="stellarwp-telemetry">
 				<?php wp_nonce_field( 'stellarwp-telemetry' ); ?>
 				<button class="stellarwp-telemetry-btn-primary" data-js="form-submit" type="submit" name="optin-agreed" value="true">

--- a/src/views/optin.php
+++ b/src/views/optin.php
@@ -54,7 +54,7 @@
 		</main>
 		<footer>
 			<form method="post" action="" data-js="optin-form">
-				<input type="hidden" name="page" value="<?php echo esc_attr( $_GET['page'] ); // phpcs:ignore WordPress.Security ?>">
+				<input type="hidden" name="page" value="<?php echo esc_attr( issest( $_GET['page'] ) ? $_GET['page'] : '' ); // phpcs:ignore WordPress.Security ?>">
 				<input type="hidden" name="action" value="stellarwp-telemetry">
 				<?php wp_nonce_field( 'stellarwp-telemetry' ); ?>
 				<button class="stellarwp-telemetry-btn-primary" data-js="form-submit" type="submit" name="optin-agreed" value="true">


### PR DESCRIPTION
Although nobody should be loading the library on a WP Admin page that doesn't include the `$_GET['page']` variable, we should still check to make sure that it exists before using it. 

This change will allow developers to add the telemetry action to load the modal on any page in the WordPress admin as long as it is only called once. 

for example this now works:
```
		add_action( 'admin_footer', function(){
			do_action( 'stellarwp/telemetry/telemetry-starter/optin' );
		}, 1, 0 );
```
