### PR TITLE
Fix several filter slugs that are missing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ $args = [
 	'privacy_url'           => '#',
 	'opted_in_plugins_text' => __( 'See which plugins you have opted in to tracking for', 'stellarwp-telemetry' ),
 	'heading'               => __( 'We hope you love {plugin_name}.', 'stellarwp-telemetry' ),
-	'intro'                 => __( 'Hi, {user_name}.! This is an invitation to help our StellarWP community. If you opt-in, some data about your usage of {plugin_name} and future StellarWP Products will be shared with our teams (so they can work their butts off to improve). We will also share some helpful info on WordPress, and our products from time to time. And if you skip this, that’s okay! Our products still work just fine.', 'stellarwp-telemetry' ),
+	'intro'                 => __( 'Hi, {user_name}! This is an invitation to help our StellarWP community. If you opt-in, some data about your usage of {plugin_name} and future StellarWP Products will be shared with our teams (so they can work their butts off to improve). We will also share some helpful info on WordPress, and our products from time to time. And if you skip this, that’s okay! Our products still work just fine.', 'stellarwp-telemetry' ),
 ];
 ```
 ### stellarwp/telemetry/{hook-prefix}/show_optin_option_name

--- a/src/Telemetry/Admin/Resources.php
+++ b/src/Telemetry/Admin/Resources.php
@@ -52,7 +52,7 @@ class Resources {
 		 *
 		 * @param string $path The path to the admin JS script.
 		 */
-		$script_path = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'script_path', $this->get_asset_path() . 'resources/js/scripts.js' );
+		$script_path = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/script_path', $this->get_asset_path() . 'resources/js/scripts.js' );
 
 		wp_enqueue_script(
 			self::SCRIPT_HANDLE,
@@ -79,7 +79,7 @@ class Resources {
 		 * @param array $data The data to pass to the script.
 		 */
 		$script_data = apply_filters(
-			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'script_data',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/script_data',
 			[
 				'exit_interview' => [
 					'action' => Exit_Interview_Subscriber::AJAX_ACTION,
@@ -110,7 +110,7 @@ class Resources {
 		 *
 		 * @param string $path The path to the CSS file.
 		 */
-		$style_path = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'style_path', $this->get_asset_path() . 'resources/css/styles.css' );
+		$style_path = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/style_path', $this->get_asset_path() . 'resources/css/styles.css' );
 
 		wp_enqueue_style(
 			self::SCRIPT_HANDLE,

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -133,7 +133,7 @@ class Template implements Template_Interface {
 		 *
 		 * @param bool $should_render Whether the modal should render.
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'exit_interview_should_render', true );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/exit_interview_should_render', true );
 	}
 
 	/**

--- a/src/Telemetry/Last_Send/Last_Send.php
+++ b/src/Telemetry/Last_Send/Last_Send.php
@@ -61,7 +61,7 @@ class Last_Send {
 		 *
 		 * @param integer $expire_seconds
 		 */
-		$expire_seconds = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'last_send_expire_seconds', 7 * DAY_IN_SECONDS );
+		$expire_seconds = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/last_send_expire_seconds', 7 * DAY_IN_SECONDS );
 
 		$last_run_time = new DateTimeImmutable( $last_send );
 		$next_run_time = $last_run_time->add( new \DateInterval( "PT{$expire_seconds}S" ) );

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -132,7 +132,7 @@ class Opt_In_Template implements Template_Interface {
 		 * @param string $show_optin_option_name
 		 */
 		return apply_filters(
-			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'show_optin_option_name',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/show_optin_option_name',
 			'stellarwp_telemetry_' . Config::get_stellar_slug() . '_show_optin'
 		);
 	}

--- a/src/Telemetry/Opt_In/Status.php
+++ b/src/Telemetry/Opt_In/Status.php
@@ -40,7 +40,7 @@ class Status {
 		 *
 		 * @param string $option_name
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'option_name', self::OPTION_NAME );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/option_name', self::OPTION_NAME );
 	}
 
 	/**
@@ -97,7 +97,7 @@ class Status {
 		 *
 		 * @param integer $status The opt-in status value.
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'optin_status', $status );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/optin_status', $status );
 	}
 
 	/**
@@ -117,7 +117,7 @@ class Status {
 		 *
 		 * @param string $token The site's auth token.
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'token', $option['token'] ?? '' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/token', $option['token'] ?? '' );
 	}
 
 	/**
@@ -256,7 +256,7 @@ class Status {
 		 *
 		 * @param string $optin-Label
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'optin_status_label', $optin_label );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/optin_status_label', $optin_label );
 	}
 
 	/**

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -197,7 +197,7 @@ class Telemetry {
 		 *
 		 * @param string $site_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_url', Config::get_server_url() . '/register-site' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_url', Config::get_server_url() . '/register-site' );
 	}
 
 	/**
@@ -215,7 +215,7 @@ class Telemetry {
 		 *
 		 * @param string $uninstall_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'uninstall_url', Config::get_server_url() . '/uninstall' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/uninstall_url', Config::get_server_url() . '/uninstall' );
 	}
 
 	/**
@@ -234,7 +234,7 @@ class Telemetry {
 		 * @param array $register_site_data
 		 */
 		return apply_filters(
-			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_data',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_data',
 			[
 				'telemetry'     => wp_json_encode( $this->provider->get_data() ),
 				'stellar_slugs' => wp_json_encode( $this->opt_in_status->get_opted_in_plugins() ),
@@ -260,7 +260,7 @@ class Telemetry {
 		 * @param array $site_user_details
 		 */
 		$user_info = apply_filters(
-			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_user_details',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_user_details',
 			[
 				'name'        => $user->display_name,
 				'email'       => $user->user_email,
@@ -346,7 +346,7 @@ class Telemetry {
 	 */
 	protected function get_send_data_args() {
 		return apply_filters(
-			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'send_data_args',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/send_data_args',
 			[
 				'token'         => $this->get_token(),
 				'telemetry'     => wp_json_encode( $this->provider->get_data() ),
@@ -370,7 +370,7 @@ class Telemetry {
 		 *
 		 * @param string $data_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'send_data_url', Config::get_server_url() . '/telemetry' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/send_data_url', Config::get_server_url() . '/telemetry' );
 	}
 
 	/**


### PR DESCRIPTION
...after uses of Config::get_hook_prefix() and Config::get_stellar_slug()

All of these that are in the readme are listed with the slash, the rest aren't in the readme