### PR TITLE
Deprecate and replace several filter slugs that are missing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ $args = [
 	'privacy_url'           => '#',
 	'opted_in_plugins_text' => __( 'See which plugins you have opted in to tracking for', 'stellarwp-telemetry' ),
 	'heading'               => __( 'We hope you love {plugin_name}.', 'stellarwp-telemetry' ),
-	'intro'                 => __( 'Hi, {user_name}.! This is an invitation to help our StellarWP community. If you opt-in, some data about your usage of {plugin_name} and future StellarWP Products will be shared with our teams (so they can work their butts off to improve). We will also share some helpful info on WordPress, and our products from time to time. And if you skip this, that’s okay! Our products still work just fine.', 'stellarwp-telemetry' ),
+	'intro'                 => __( 'Hi, {user_name}! This is an invitation to help our StellarWP community. If you opt-in, some data about your usage of {plugin_name} and future StellarWP Products will be shared with our teams (so they can work their butts off to improve). We will also share some helpful info on WordPress, and our products from time to time. And if you skip this, that’s okay! Our products still work just fine.', 'stellarwp-telemetry' ),
 ];
 ```
 ### stellarwp/telemetry/{hook-prefix}/show_optin_option_name

--- a/src/Telemetry/Admin/Resources.php
+++ b/src/Telemetry/Admin/Resources.php
@@ -45,14 +45,35 @@ class Resources {
 	 * @return void
 	 */
 	public function enqueue_scripts() {
+		$script_path = $this->get_asset_path() . 'resources/js/scripts.js';
+
 		/**
 		 * Filters the path to the admin JS script.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
-		 * @param string $path The path to the admin JS script.
+		 * @param string $script_path The path to the admin JS script.
 		 */
-		$script_path = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/script_path', $this->get_asset_path() . 'resources/js/scripts.js' );
+		$script_path = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'script_path',
+			$script_path,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/script_path',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the path to the admin JS script.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $script_path The path to the admin JS script.
+		 */
+		$script_path = apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/script_path',
+			$script_path
+		);
 
 		wp_enqueue_script(
 			self::SCRIPT_HANDLE,
@@ -71,21 +92,39 @@ class Resources {
 	 * @return void
 	 */
 	public function localize_script() {
+		$script_data = [
+			'exit_interview' => [
+				'action' => Exit_Interview_Subscriber::AJAX_ACTION,
+				'nonce'  => wp_create_nonce( Exit_Interview_Subscriber::AJAX_ACTION ),
+			],
+		];
+
 		/**
 		 * Filters the data that is passed to the admin JS script.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
-		 * @param array $data The data to pass to the script.
+		 * @param array $script_data The data to pass to the script.
+		 */
+		$script_data = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'script_data',
+			$script_data,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/script_data',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the data that is passed to the admin JS script.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $script_data The data to pass to the script.
 		 */
 		$script_data = apply_filters(
 			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/script_data',
-			[
-				'exit_interview' => [
-					'action' => Exit_Interview_Subscriber::AJAX_ACTION,
-					'nonce'  => wp_create_nonce( Exit_Interview_Subscriber::AJAX_ACTION ),
-				],
-			]
+			$script_data
 		);
 
 		wp_localize_script(
@@ -103,14 +142,35 @@ class Resources {
 	 * @return void
 	 */
 	public function enqueue_styles() {
+		$style_path = $this->get_asset_path() . 'resources/css/styles.css';
+
 		/**
 		 * Filters the path to the admin CSS styles.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
-		 * @param string $path The path to the CSS file.
+		 * @param string $style_path The path to the CSS file.
 		 */
-		$style_path = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/style_path', $this->get_asset_path() . 'resources/css/styles.css' );
+		$style_path = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'style_path',
+			$style_path,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/style_path',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the path to the admin CSS styles.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $style_path The path to the CSS file.
+		 */
+		$style_path = apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/style_path',
+			$style_path
+		);
 
 		wp_enqueue_style(
 			self::SCRIPT_HANDLE,

--- a/src/Telemetry/Admin/Resources.php
+++ b/src/Telemetry/Admin/Resources.php
@@ -52,7 +52,7 @@ class Resources {
 		 *
 		 * @param string $path The path to the admin JS script.
 		 */
-		$script_path = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'script_path', $this->get_asset_path() . 'resources/js/scripts.js' );
+		$script_path = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/script_path', $this->get_asset_path() . 'resources/js/scripts.js' );
 
 		wp_enqueue_script(
 			self::SCRIPT_HANDLE,
@@ -79,7 +79,7 @@ class Resources {
 		 * @param array $data The data to pass to the script.
 		 */
 		$script_data = apply_filters(
-			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'script_data',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/script_data',
 			[
 				'exit_interview' => [
 					'action' => Exit_Interview_Subscriber::AJAX_ACTION,
@@ -110,7 +110,7 @@ class Resources {
 		 *
 		 * @param string $path The path to the CSS file.
 		 */
-		$style_path = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'style_path', $this->get_asset_path() . 'resources/css/styles.css' );
+		$style_path = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/style_path', $this->get_asset_path() . 'resources/css/styles.css' );
 
 		wp_enqueue_style(
 			self::SCRIPT_HANDLE,

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -126,14 +126,35 @@ class Template implements Template_Interface {
 	 * @return boolean
 	 */
 	public function should_render() {
+		$should_render = true;
+
 		/**
 		 * Filters whether the "Exit Interview" modal should render.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
 		 * @param bool $should_render Whether the modal should render.
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/exit_interview_should_render', true );
+		$should_render = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'exit_interview_should_render',
+			$should_render,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/exit_interview_should_render',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters whether the "Exit Interview" modal should render.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $should_render Whether the modal should render.
+		 */
+		return apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/exit_interview_should_render',
+			$should_render
+		);
 	}
 
 	/**

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -133,7 +133,7 @@ class Template implements Template_Interface {
 		 *
 		 * @param bool $should_render Whether the modal should render.
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'exit_interview_should_render', true );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/exit_interview_should_render', true );
 	}
 
 	/**

--- a/src/Telemetry/Last_Send/Last_Send.php
+++ b/src/Telemetry/Last_Send/Last_Send.php
@@ -61,7 +61,7 @@ class Last_Send {
 		 *
 		 * @param integer $expire_seconds
 		 */
-		$expire_seconds = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'last_send_expire_seconds', 7 * DAY_IN_SECONDS );
+		$expire_seconds = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/last_send_expire_seconds', 7 * DAY_IN_SECONDS );
 
 		$last_run_time = new DateTimeImmutable( $last_send );
 		$next_run_time = $last_run_time->add( new \DateInterval( "PT{$expire_seconds}S" ) );

--- a/src/Telemetry/Last_Send/Last_Send.php
+++ b/src/Telemetry/Last_Send/Last_Send.php
@@ -46,7 +46,6 @@ class Last_Send {
 	 * @return bool
 	 */
 	public function is_expired() {
-
 		$last_send = $this->get_timestamp();
 
 		// No timestamp exists, we'll assume that telemetry data needs to be sent.
@@ -54,14 +53,35 @@ class Last_Send {
 			return true;
 		}
 
+		$expire_seconds = 7 * DAY_IN_SECONDS;
+
 		/**
 		 * Filters the amount of seconds the last send timestamp is valid before it expires.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
 		 * @param integer $expire_seconds
 		 */
-		$expire_seconds = apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/last_send_expire_seconds', 7 * DAY_IN_SECONDS );
+		$expire_seconds = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'last_send_expire_seconds',
+			$expire_seconds,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/last_send_expire_seconds',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the amount of seconds the last send timestamp is valid before it expires.
+		 *
+		 * @since TBD
+		 *
+		 * @param integer $expire_seconds
+		 */
+		$expire_seconds = apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/last_send_expire_seconds',
+			$expire_seconds
+		);
 
 		$last_run_time = new DateTimeImmutable( $last_send );
 		$next_run_time = $last_run_time->add( new \DateInterval( "PT{$expire_seconds}S" ) );

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -132,7 +132,7 @@ class Opt_In_Template implements Template_Interface {
 		 * @param string $show_optin_option_name
 		 */
 		return apply_filters(
-			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'show_optin_option_name',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/show_optin_option_name',
 			'stellarwp_telemetry_' . Config::get_stellar_slug() . '_show_optin'
 		);
 	}

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -124,16 +124,34 @@ class Opt_In_Template implements Template_Interface {
 	 * @return string
 	 */
 	public function get_option_name() {
+		$show_optin_option_name = 'stellarwp_telemetry_' . Config::get_stellar_slug() . '_show_optin';
+
 		/**
 		 * Filters the name of the option stored in the options table.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
+		 *
+		 * @param string $show_optin_option_name
+		 */
+		$show_optin_option_name = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'show_optin_option_name',
+			$show_optin_option_name,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/show_optin_option_name',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the name of the option stored in the options table.
+		 *
+		 * @since TBD
 		 *
 		 * @param string $show_optin_option_name
 		 */
 		return apply_filters(
 			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/show_optin_option_name',
-			'stellarwp_telemetry_' . Config::get_stellar_slug() . '_show_optin'
+			$show_optin_option_name
 		);
 	}
 

--- a/src/Telemetry/Opt_In/Status.php
+++ b/src/Telemetry/Opt_In/Status.php
@@ -40,7 +40,7 @@ class Status {
 		 *
 		 * @param string $option_name
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'option_name', self::OPTION_NAME );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/option_name', self::OPTION_NAME );
 	}
 
 	/**
@@ -97,7 +97,7 @@ class Status {
 		 *
 		 * @param integer $status The opt-in status value.
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'optin_status', $status );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/optin_status', $status );
 	}
 
 	/**
@@ -117,7 +117,7 @@ class Status {
 		 *
 		 * @param string $token The site's auth token.
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'token', $option['token'] ?? '' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/token', $option['token'] ?? '' );
 	}
 
 	/**
@@ -256,7 +256,7 @@ class Status {
 		 *
 		 * @param string $optin-Label
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'optin_status_label', $optin_label );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/optin_status_label', $optin_label );
 	}
 
 	/**

--- a/src/Telemetry/Opt_In/Status.php
+++ b/src/Telemetry/Opt_In/Status.php
@@ -33,14 +33,35 @@ class Status {
 	 * @return string
 	 */
 	public function get_option_name() {
+		$option_name = self::OPTION_NAME;
+
 		/**
 		 * Filters the option name used to store the opt-in status.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
 		 * @param string $option_name
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/option_name', self::OPTION_NAME );
+		$option_name = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'option_name',
+			$option_name,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/option_name',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the option name used to store the opt-in status.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $option_name
+		 */
+		return apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/option_name',
+			$option_name
+		);
 	}
 
 	/**
@@ -94,10 +115,29 @@ class Status {
 		 * Filters the opt-in status value.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
 		 * @param integer $status The opt-in status value.
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/optin_status', $status );
+		$status = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'optin_status',
+			$status,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/optin_status',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the opt-in status value.
+		 *
+		 * @since TBD
+		 *
+		 * @param integer $status The opt-in status value.
+		 */
+		return apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/optin_status',
+			$status
+		);
 	}
 
 	/**
@@ -109,15 +149,35 @@ class Status {
 	 */
 	public function get_token() {
 		$option = $this->get_option();
+		$token = $option['token'] ?? '';
 
 		/**
 		 * Filters the site auth token.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
 		 * @param string $token The site's auth token.
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/token', $option['token'] ?? '' );
+		$token = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'token',
+			$token,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/token',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the site auth token.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $token The site's auth token.
+		 */
+		return apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/token',
+			$token
+		);
 	}
 
 	/**
@@ -253,10 +313,29 @@ class Status {
 		 * Filters the opt-in status label.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
-		 * @param string $optin-Label
+		 * @param string $optin_label
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/optin_status_label', $optin_label );
+		$optin_label = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'optin_status_label',
+			$optin_label,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/optin_status_label',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the opt-in status label.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $optin_label
+		 */
+		return apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/optin_status_label',
+			$optin_label
+		);
 	}
 
 	/**

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -197,7 +197,7 @@ class Telemetry {
 		 *
 		 * @param string $site_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_url', Config::get_server_url() . '/register-site' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_url', Config::get_server_url() . '/register-site' );
 	}
 
 	/**
@@ -215,7 +215,7 @@ class Telemetry {
 		 *
 		 * @param string $uninstall_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'uninstall_url', Config::get_server_url() . '/uninstall' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/uninstall_url', Config::get_server_url() . '/uninstall' );
 	}
 
 	/**
@@ -234,7 +234,7 @@ class Telemetry {
 		 * @param array $register_site_data
 		 */
 		return apply_filters(
-			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_data',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_data',
 			[
 				'telemetry'     => wp_json_encode( $this->provider->get_data() ),
 				'stellar_slugs' => wp_json_encode( $this->opt_in_status->get_opted_in_plugins() ),
@@ -260,7 +260,7 @@ class Telemetry {
 		 * @param array $site_user_details
 		 */
 		$user_info = apply_filters(
-			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_user_details',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_user_details',
 			[
 				'name'        => $user->display_name,
 				'email'       => $user->user_email,
@@ -346,7 +346,7 @@ class Telemetry {
 	 */
 	protected function get_send_data_args() {
 		return apply_filters(
-			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'send_data_args',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/send_data_args',
 			[
 				'token'         => $this->get_token(),
 				'telemetry'     => wp_json_encode( $this->provider->get_data() ),
@@ -370,7 +370,7 @@ class Telemetry {
 		 *
 		 * @param string $data_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'send_data_url', Config::get_server_url() . '/telemetry' );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/send_data_url', Config::get_server_url() . '/telemetry' );
 	}
 
 	/**

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -190,14 +190,35 @@ class Telemetry {
 	 * @return string
 	 */
 	protected function get_register_site_url() {
+		$site_url = Config::get_server_url() . '/register-site';
+
 		/**
 		 * Filters the registered site url.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
 		 * @param string $site_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_url', Config::get_server_url() . '/register-site' );
+		$site_url = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_url',
+			$site_url,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_url',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the registered site url.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $site_url
+		 */
+		return apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_url',
+			$site_url
+		);
 	}
 
 	/**
@@ -208,14 +229,36 @@ class Telemetry {
 	 * @return string
 	 */
 	protected function get_uninstall_url() {
+		$uninstall_url = Config::get_server_url() . '/uninstall';
+
 		/**
 		 * Filters the uninstall url.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
 		 * @param string $uninstall_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/uninstall_url', Config::get_server_url() . '/uninstall' );
+		$uninstall_url = apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'uninstall_url',
+			$uninstall_url,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/uninstall_url',
+			'Replace missing `/` in handle'
+		);
+
+
+		/**
+		 * Filters the uninstall url.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $uninstall_url
+		 */
+		return apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/uninstall_url',
+			$uninstall_url
+		);
 	}
 
 	/**
@@ -226,19 +269,37 @@ class Telemetry {
 	 * @return array
 	 */
 	protected function get_register_site_data() {
+		$register_site_data = [
+			'telemetry'     => wp_json_encode( $this->provider->get_data() ),
+			'stellar_slugs' => wp_json_encode( $this->opt_in_status->get_opted_in_plugins() ),
+		];
+
 		/**
 		 * Filters the register site data.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
+		 *
+		 * @param array $register_site_data
+		 */
+		$register_site_data = apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_data',
+			$register_site_data,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_data',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the register site data.
+		 *
+		 * @since TBD
 		 *
 		 * @param array $register_site_data
 		 */
 		return apply_filters(
 			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_data',
-			[
-				'telemetry'     => wp_json_encode( $this->provider->get_data() ),
-				'stellar_slugs' => wp_json_encode( $this->opt_in_status->get_opted_in_plugins() ),
-			]
+			$register_site_data
 		);
 	}
 
@@ -250,22 +311,39 @@ class Telemetry {
 	 * @return array
 	 */
 	protected function get_user_details() {
-		$user = wp_get_current_user();
+		$user      = wp_get_current_user();
+		$user_info = [
+			'name'        => $user->display_name,
+			'email'       => $user->user_email,
+			'plugin_slug' => Config::get_stellar_slug(),
+		];
 
 		/**
 		 * Filters the site user details.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
+		 *
+		 * @param array $site_user_details
+		 */
+		$user_info = apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'register_site_user_details',
+			$user_info,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_user_details',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filters the site user details.
+		 *
+		 * @since TBD
 		 *
 		 * @param array $site_user_details
 		 */
 		$user_info = apply_filters(
 			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/register_site_user_details',
-			[
-				'name'        => $user->display_name,
-				'email'       => $user->user_email,
-				'plugin_slug' => Config::get_stellar_slug(),
-			]
+			$user_info
 		);
 
 		return [ 'user' => wp_json_encode( $user_info ) ];
@@ -345,13 +423,38 @@ class Telemetry {
 	 * @return array
 	 */
 	protected function get_send_data_args() {
+		$send_data_args = [
+			'token'         => $this->get_token(),
+			'telemetry'     => wp_json_encode( $this->provider->get_data() ),
+			'stellar_slugs' => wp_json_encode( $this->opt_in_status->get_opted_in_plugins() ),
+		];
+
+		/**
+		 * Filter the args for sending data to the telemetry server.
+		 *
+		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
+		 *
+		 * @param array $send_data_args
+		 */
+		$send_data_args = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'send_data_args',
+			$send_data_args,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/send_data_args',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filter the args for sending data to the telemetry server.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $send_data_args
+		 */
 		return apply_filters(
 			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/send_data_args',
-			[
-				'token'         => $this->get_token(),
-				'telemetry'     => wp_json_encode( $this->provider->get_data() ),
-				'stellar_slugs' => wp_json_encode( $this->opt_in_status->get_opted_in_plugins() ),
-			]
+			$send_data_args
 		);
 	}
 
@@ -363,14 +466,35 @@ class Telemetry {
 	 * @return string
 	 */
 	protected function get_send_data_url() {
+		$data_url = Config::get_server_url() . '/telemetry';
+
 		/**
 		 * Filter the url for sending data to the telemetry server.
 		 *
 		 * @since 1.0.0
+		 * @deprecated TBD Correct a typo in the handle.
 		 *
 		 * @param string $data_url
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/send_data_url', Config::get_server_url() . '/telemetry' );
+		$data_url = apply_filters_deprecated(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'send_data_url',
+			$data_url,
+			'TBD',
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/send_data_url',
+			'Replace missing `/` in handle'
+		);
+
+		/**
+		 * Filter the url for sending data to the telemetry server.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $data_url
+		 */
+		return apply_filters(
+			'stellarwp/telemetry/' . Config::get_hook_prefix() . '/send_data_url',
+			$data_url
+		);
 	}
 
 	/**


### PR DESCRIPTION
...after uses of `Config::get_hook_prefix()` and `Config::get_stellar_slug()`

All of these that are in the readme are listed with the slash, the rest aren't in the readme.

All have been properly deprecated. 
I know the variable didn't need to be set first in some cases, but it makes it a bit clearer what is going on - something that can be difficult with deprecated filters.

TBDs for version number need to be changed.

Also fixed a typo that was bugging me 😉 