### PR TITLE
[FRAME-138]: Allow Multiple Stellar Slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A library for Opt-in and Telemetry data to be sent to the StellarWP Telemetry se
 		- [Prompting Users on a Settings Page](#prompting-users-on-a-settings-page)
 	- [Saving Opt-In Status on a Settings Page](#saving-opt-in-status-on-a-settings-page)
 	- [How to Migrate Users Who Have Already Opted In](#how-to-migrate-users-who-have-already-opted-in)
+	- [Utilizing a Shared Telemetry Instance](#utilizing-a-shared-telemetry-instance)
 	- [Filter Reference](#filter-reference)
 		- [stellarwp/telemetry/{hook-prefix}/should\_show\_optin](#stellarwptelemetryhook-prefixshould_show_optin)
 		- [stellarwp/telemetry/{hook-prefix}/option\_name](#stellarwptelemetryhook-prefixoption_name)
@@ -120,9 +121,19 @@ When a user deletes the plugin, WordPress runs the method from `Uninstall` and c
 ## Opt-In Modal Usage
 
 ### Prompting Users on a Settings Page
-On each settings page you'd like to prompt the user to opt-in, add a `do_action()`. _Be sure to include your defined stellar\_slug if you are using one_.
+On each settings page you'd like to prompt the user to opt-in, add a `do_action()`. _Be sure to include your defined stellar\_slug_.
 ```php
 do_action( 'stellarwp/telemetry/optin', '{stellar_slug}' );
+```
+
+Or, if you're implementing the library prior to version 3.0.0:
+```php
+/**
+ * Planned Deprecation: 3.0.0
+ *
+ * Please use 'stellarwp/telemetry/optin' action instead.
+ */
+do_action( 'stellarwp/telemetry/{stellar_slug}/optin' );
 ```
 The library calls this action to handle registering the required resources needed to render the modal. It will only display the modal for users who haven't yet opted in.
 
@@ -187,6 +198,30 @@ function migrate_existing_opt_in() {
 		$Opt_In_Subscriber = Config::get_container()->get( Opt_In_Subscriber::class );
 		$Opt_In_Subscriber->opt_in();
 	}
+}
+```
+
+## Utilizing a Shared Telemetry Instance
+
+There are cases where a plugin may want to use a shared instance of the library.
+
+The best example of this would be an add-on plugin connecting and using the Telemetry instance of its parent plugin.
+
+In this case, all that the plugin needs to do to implement the parent Telemetry instance is use `Config::add_stellar_slug()`.
+```php
+use STRAUSS_PREFIX\StellarWP\Telemetry\Config;
+
+add_action( 'plugins_loaded', 'add_plugin_to_telemetry' );
+
+function add_plugin_to_telemetry() {
+
+	// Verify that Telemetry is available.
+	if ( ! class_exists( Config::class ) ) {
+        return;
+    }
+
+	// Set a unique plugin slug and include the plugin basename.
+	Config::add_stellar_slug( 'my-custom-stellar-slug', 'my-custom-stellar-slug/my-custom-stellar-slug.php' );
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A library for Opt-in and Telemetry data to be sent to the StellarWP Telemetry se
 		- [stellarwp/telemetry/{hook-prefix}/option\_name](#stellarwptelemetryhook-prefixoption_name)
 		- [stellarwp/telemetry/{hook-prefix}/optin\_status](#stellarwptelemetryhook-prefixoptin_status)
 		- [stellarwp/telemetry/{hook-prefix}/optin\_status\_label](#stellarwptelemetryhook-prefixoptin_status_label)
+		- [stellarwp/telemetry/optin\_args](#stellarwptelemetryoptin_args)
 		- [stellarwp/telemetry/{stellar\_slug}/optin\_args](#stellarwptelemetrystellar_slugoptin_args)
 		- [stellarwp/telemetry/{hook-prefix}/show\_optin\_option\_name](#stellarwptelemetryhook-prefixshow_optin_option_name)
 		- [stellarwp/telemetry/{hook-prefix}/register\_site\_url](#stellarwptelemetryhook-prefixregister_site_url)
@@ -26,6 +27,7 @@ A library for Opt-in and Telemetry data to be sent to the StellarWP Telemetry se
 		- [stellarwp/telemetry/{hook-prefix}/send\_data\_args](#stellarwptelemetryhook-prefixsend_data_args)
 		- [stellarwp/telemetry/{hook-prefix}/send\_data\_url](#stellarwptelemetryhook-prefixsend_data_url)
 		- [stellarwp/telemetry/{hook-prefix}/last\_send\_expire\_seconds](#stellarwptelemetryhook-prefixlast_send_expire_seconds)
+		- [stellarwp/telemetry/exit\_interview\_args](#stellarwptelemetryexit_interview_args)
 		- [stellarwp/telemetry/{stellar\_slug}/exit\_interview\_args](#stellarwptelemetrystellar_slugexit_interview_args)
 	- [Adding Plugin Data to Site Health](#adding-plugin-data-to-site-health)
 ## Installation
@@ -85,6 +87,21 @@ function initialize_telemetry() {
 Using a custom hook prefix provides the ability to uniquely filter functionality of your plugin's specific instance of the library.
 
 The unique plugin slug is used by the telemetry server to identify the plugin regardless of the plugin's directory structure or slug.
+
+If you need to hook into an existing instance of the library, you can add your plugin's stellar slug with:
+```php
+add_action( 'plugins_loaded', 'hook_into_existing_telemetry' );
+
+function hook_into_existing_telemetry() {
+	// Check to make sure that the Telemetry library is already instantiated.
+	if ( ! class_exists( Telemetry::class ) ) {
+		return;
+	}
+
+	// Register the current plugin with an already instantiated library.
+	Config::add_stellar_slug( 'my-custom-stellar-slug', 'custom-plugin/custom-plugin.php' );
+}
+```
 
 ## Uninstall Hook
 
@@ -212,10 +229,10 @@ Filter the label used to show the current opt-in status of the site.
 **Parameters**: _string_ `$optin_label`
 
 **Default**: see: [stellarwp/telemetry/optin_status](#stellarwptelemetryoptin_status)
-### stellarwp/telemetry/{stellar_slug}/optin_args
+### stellarwp/telemetry/optin_args
 Filter the arguments passed to the opt-in modal.
 
-**Parameters**: _array_ `$args`
+**Parameters**: _array_ `$args`, _string_ `$stellar_slug`
 
 **Default**:
 ```php
@@ -225,7 +242,7 @@ $args = [
 	'plugin_logo_height'    => 32,
 	'plugin_logo_alt'       => 'StellarWP Logo',
 	'plugin_name'           => 'The Events Calendar',
-	'plugin_slug'           => Config::get_container()->get( Core::PLUGIN_SLUG ),
+	'plugin_slug'           => $stellar_slug,
 	'user_name'             => wp_get_current_user()->display_name,
 	'permissions_url'       => '#',
 	'tos_url'               => '#',
@@ -235,6 +252,9 @@ $args = [
 	'intro'                 => __( 'Hi, {user_name}.! This is an invitation to help our StellarWP community. If you opt-in, some data about your usage of {plugin_name} and future StellarWP Products will be shared with our teams (so they can work their butts off to improve). We will also share some helpful info on WordPress, and our products from time to time. And if you skip this, that’s okay! Our products still work just fine.', 'stellarwp-telemetry' ),
 ];
 ```
+### stellarwp/telemetry/{stellar_slug}/optin_args
+This filter will be deprecated in future versions. Use [stellarwp/telemetry/optin_args](#stellarwptelemetrystellar_slugoptin_args) instead.
+
 ### stellarwp/telemetry/{hook-prefix}/show_optin_option_name
 Filters the string used for the option that determines whether the opt-in modal should be shown.
 
@@ -297,15 +317,15 @@ Filters how often the library should send site health data to the telemetry serv
 
 **Default**: `7 * DAY_IN_SECONDS`
 
-### stellarwp/telemetry/{stellar_slug}/exit_interview_args
+### stellarwp/telemetry/exit_interview_args
 Filters the arguments used in the plugin deactivation "exit interview" form.
 
-**Parameters**: _array_ `$args`
+**Parameters**: _array_ `$args`, _string_ `$stellar_slug`
 
 **Default**:
 ```php
 $args = [
-	'plugin_slug'        => $this->container->get( Core::PLUGIN_SLUG ),
+	'plugin_slug'        => $stellar_slug,
 	'plugin_logo'        => plugin_dir_url( __DIR__ ) . 'public/logo.png',
 	'plugin_logo_width'  => 151,
 	'plugin_logo_height' => 32,
@@ -336,6 +356,9 @@ $args = [
 	],
 ];
 ```
+
+### stellarwp/telemetry/{stellar_slug}/exit_interview_args
+This filter will be deprecated in future versions. Use [stellarwp/telemetry/exit_interview_args](#stellarwptelemetrystellar_slugexit_interview_args) instead.
 
 ## Adding Plugin Data to Site Health
 

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ When a user deletes the plugin, WordPress runs the method from `Uninstall` and c
 ### Prompting Users on a Settings Page
 On each settings page you'd like to prompt the user to opt-in, add a `do_action()`. _Be sure to include your defined stellar\_slug if you are using one_.
 ```php
-do_action( 'stellarwp/telemetry/{stellar_slug}/optin' );
+do_action( 'stellarwp/telemetry/optin', '{stellar_slug}' );
 ```
 The library calls this action to handle registering the required resources needed to render the modal. It will only display the modal for users who haven't yet opted in.
 
 To show the modal on a settings page, add the `do_action()` to the top of your rendered page content:
 ```php
 function my_options_page() {
-    do_action( 'stellarwp/telemetry/{stellar_slug}/optin' );
+    do_action( 'stellarwp/telemetry/optin', '{stellar_slug}' );
     ?>
     <div>
         <h2>My Plugin Settings Page</h2>
@@ -122,7 +122,7 @@ function my_options_page() {
 ```
 _Note: When adding the `do_action`, you may pass additional arguments to the library with an array. There is no functionality at the moment, but we expect to expand the library to accept configuration through the passed array._
 ```php
-do_action( 'stellarwp/telemetry/{stellar_slug}/optin', [ 'plugin_slug' => 'the-events-calendar' ] );
+do_action( 'stellarwp/telemetry/optin', '{stellar_slug}', [ 'plugin_slug' => 'the-events-calendar' ] );
 ```
 
 ## Saving Opt-In Status on a Settings Page

--- a/src/Telemetry/Admin/Admin_Subscriber.php
+++ b/src/Telemetry/Admin/Admin_Subscriber.php
@@ -47,7 +47,7 @@ class Admin_Subscriber extends Abstract_Subscriber {
 
 		$should_render = false;
 
-		foreach ( Config::get_all_stellar_slugs() as $stellar_slug ) {
+		foreach ( Config::get_all_stellar_slugs() as $stellar_slug => $wp_slug ) {
 			$should_render = $this->container->get( Opt_In_Template::class )->should_render( $stellar_slug );
 
 			if ( $should_render ) {

--- a/src/Telemetry/Admin/Admin_Subscriber.php
+++ b/src/Telemetry/Admin/Admin_Subscriber.php
@@ -9,6 +9,7 @@
 
 namespace StellarWP\Telemetry\Admin;
 
+use StellarWP\Telemetry\Config;
 use StellarWP\Telemetry\Contracts\Abstract_Subscriber;
 use StellarWP\Telemetry\Opt_In\Opt_In_Template;
 
@@ -37,13 +38,24 @@ class Admin_Subscriber extends Abstract_Subscriber {
 	 * Registers required hooks to set up the admin assets.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Adjust to output assets if any stellar slug should render its modal.
 	 *
 	 * @return void
 	 */
 	public function maybe_enqueue_admin_assets() {
 		global $pagenow;
 
-		if ( 'plugins.php' === $pagenow || $this->container->get( Opt_In_Template::class )->should_render() ) {
+		$should_render = false;
+
+		foreach ( Config::get_all_stellar_slugs() as $stellar_slug ) {
+			$should_render = $this->container->get( Opt_In_Template::class )->should_render( $stellar_slug );
+
+			if ( $should_render ) {
+				break;
+			}
+		}
+
+		if ( 'plugins.php' === $pagenow || $should_render ) {
 			$this->container->get( Resources::class )->enqueue_admin_assets();
 		}
 	}

--- a/src/Telemetry/Config.php
+++ b/src/Telemetry/Config.php
@@ -48,7 +48,7 @@ class Config {
 	protected static $stellar_slug = '';
 
 	/**
-	 * Unique IDs for the StellarWP slugs.
+	 * Unique IDs and optional plugin slugs for StellarWP slugs.
 	 *
 	 * @since 2.0.0
 	 *
@@ -120,7 +120,7 @@ class Config {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @return array
+	 * @return array<string,string>
 	 */
 	public static function get_all_stellar_slugs() {
 		return static::$stellar_slugs;
@@ -207,11 +207,12 @@ class Config {
 	 * @since 2.0.0
 	 *
 	 * @param string $stellar_slug A unique slug to add to the config.
+	 * @param string $wp_slug      The plugin's basename (used for capturing deactivation "Exit Interview" info).
 	 *
 	 * @return void
 	 */
-	public static function add_stellar_slug( string $stellar_slug ) {
-		static::$stellar_slugs[] = $stellar_slug;
+	public static function add_stellar_slug( string $stellar_slug, string $wp_slug = '' ) {
+		static::$stellar_slugs[ $stellar_slug ] = $wp_slug;
 	}
 
 	/**

--- a/src/Telemetry/Config.php
+++ b/src/Telemetry/Config.php
@@ -48,6 +48,15 @@ class Config {
 	protected static $stellar_slug = '';
 
 	/**
+	 * Unique IDs for the StellarWP slugs.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @var array
+	 */
+	protected static $stellar_slugs = [];
+
+	/**
 	 * The url of the telemetry server.
 	 *
 	 * @since 1.0.0
@@ -96,7 +105,7 @@ class Config {
 	}
 
 	/**
-	 * Gets the stellar slug server url.
+	 * Gets the stellar slug.
 	 *
 	 * @since 1.0.0
 	 *
@@ -104,6 +113,17 @@ class Config {
 	 */
 	public static function get_stellar_slug() {
 		return static::$stellar_slug;
+	}
+
+	/**
+	 * Gets the registered stellar slugs.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return array
+	 */
+	public static function get_all_stellar_slugs() {
+		return static::$stellar_slugs;
 	}
 
 	/**
@@ -161,7 +181,6 @@ class Config {
 		static::$hook_prefix = $prefix;
 	}
 
-
 	/**
 	 * Sets the stellar slug.
 	 *
@@ -173,6 +192,26 @@ class Config {
 	 */
 	public static function set_stellar_slug( string $stellar_slug ) {
 		static::$stellar_slug = $stellar_slug;
+
+		// Also add the stellar slug to the array of all registered stellar slugs.
+		static::$stellar_slugs[] = $stellar_slug;
+	}
+
+	/**
+	 * Adds a new stellar slug to the stellar slugs array.
+	 *
+	 * Utilizing an array of stellar slugs, the library can be tailored for use in a single plugin
+	 * or use within a shared library for several plugins. Each stellar slug registered will
+	 * generate unique filters and hooks that give further customization for each slug
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param string $stellar_slug A unique slug to add to the config.
+	 *
+	 * @return void
+	 */
+	public static function add_stellar_slug( string $stellar_slug ) {
+		static::$stellar_slugs[] = $stellar_slug;
 	}
 
 	/**

--- a/src/Telemetry/Config.php
+++ b/src/Telemetry/Config.php
@@ -194,9 +194,7 @@ class Config {
 		static::$stellar_slug = $stellar_slug;
 
 		// Also add the stellar slug to the array of all registered stellar slugs.
-		static::$stellar_slugs[] = [
-			$stellar_slug => '',
-		];
+		static::$stellar_slugs[ $stellar_slug ] = '';
 	}
 
 	/**

--- a/src/Telemetry/Config.php
+++ b/src/Telemetry/Config.php
@@ -194,7 +194,9 @@ class Config {
 		static::$stellar_slug = $stellar_slug;
 
 		// Also add the stellar slug to the array of all registered stellar slugs.
-		static::$stellar_slugs[] = $stellar_slug;
+		static::$stellar_slugs[] = [
+			$stellar_slug => '',
+		];
 	}
 
 	/**

--- a/src/Telemetry/Contracts/Template_Interface.php
+++ b/src/Telemetry/Contracts/Template_Interface.php
@@ -17,10 +17,13 @@ interface Template_Interface {
 	 * Renders the template.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Update to handle passed in stellar slug.
+	 *
+	 * @param string $stellar_slug The stellar slug to be referenced when the modal is rendered.
 	 *
 	 * @return void
 	 */
-	public function render();
+	public function render( string $stellar_slug );
 
 	/**
 	 * Enqueues assets for the rendered template.
@@ -35,8 +38,11 @@ interface Template_Interface {
 	 * Determines if the template should be rendered.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Update to handle passed in stellar slug.
+	 *
+	 * @param string $stellar_slug The stellar slug for which the modal should be rendered.
 	 *
 	 * @return boolean
 	 */
-	public function should_render();
+	public function should_render( string $stellar_slug );
 }

--- a/src/Telemetry/Core.php
+++ b/src/Telemetry/Core.php
@@ -125,6 +125,15 @@ class Core {
 	private function init_container( string $plugin_path ) {
 		$container = Config::get_container();
 
+		// For all registered stellar slugs, use the plugin basename for those that do not have a wp_slug set.
+		foreach ( Config::get_all_stellar_slugs() as $stellar_slug => $wp_slug ) {
+			if ( '' !== $wp_slug ) {
+				continue;
+			}
+
+			Config::add_stellar_slug( $stellar_slug, plugin_basename( $plugin_path ) );
+		}
+
 		$container->bind( self::PLUGIN_BASENAME, plugin_basename( $plugin_path ) );
 		$container->bind( self::PLUGIN_FILE, $plugin_path );
 		$container->bind( self::SITE_PLUGIN_DIR, dirname( plugin_dir_path( $plugin_path ) ) );

--- a/src/Telemetry/Exit_Interview/Exit_Interview_Subscriber.php
+++ b/src/Telemetry/Exit_Interview/Exit_Interview_Subscriber.php
@@ -58,7 +58,9 @@ class Exit_Interview_Subscriber extends Abstract_Subscriber {
 		global $pagenow;
 
 		if ( 'plugins.php' === $pagenow ) {
-			$this->container->get( Template::class )->maybe_render();
+			foreach ( Config::get_all_stellar_slugs() as $stellar_slug ) {
+				$this->container->get( Template::class )->maybe_render( $stellar_slug );
+			}
 		}
 	}
 

--- a/src/Telemetry/Exit_Interview/Exit_Interview_Subscriber.php
+++ b/src/Telemetry/Exit_Interview/Exit_Interview_Subscriber.php
@@ -44,7 +44,7 @@ class Exit_Interview_Subscriber extends Abstract_Subscriber {
 		add_action( 'wp_ajax_' . self::AJAX_ACTION, [ $this, 'ajax_exit_interview' ] );
 
 		add_filter( 'network_admin_plugin_action_links_' . $this->container->get( Core::PLUGIN_BASENAME ), [ $this, 'plugin_action_links' ], 10, 1 );
-		add_filter( 'plugin_action_links_' . $this->container->get( Core::PLUGIN_BASENAME ), [ $this, 'plugin_action_links' ], 10, 1 );
+		add_filter( 'plugin_action_links_' . $this->container->get( Core::PLUGIN_BASENAME ), [ $this, 'plugin_action_links' ], 10, 2 );
 	}
 
 	/**
@@ -107,13 +107,24 @@ class Exit_Interview_Subscriber extends Abstract_Subscriber {
 	 *
 	 * The deactivation is deferred to the modal displayed.
 	 *
-	 * @param array $links The links of the plugin in the plugin list.
+	 * @param array  $links        The links of the plugin in the plugin list.
+	 * @param string $plugin_file The plugin file of the current plugin in the list.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @return array
 	 */
-	public function plugin_action_links( $links ) {
+	public function plugin_action_links( $links, $plugin_file ) {
+
+		$stellar_slug = '';
+
+		foreach ( Config::get_all_stellar_slugs() as $slug => $basename ) {
+			if ( plugin_basename( $plugin_file ) === $basename ) {
+				$stellar_slug = $slug;
+				continue;
+			}
+		}
+
 		$passed_deactivate = false;
 		$deactivate_link   = '';
 		$before_deactivate = [];
@@ -134,7 +145,7 @@ class Exit_Interview_Subscriber extends Abstract_Subscriber {
 		}
 
 		if ( ! empty( $deactivate_link ) ) {
-			$deactivate_link .= '<i class="telemetry-plugin-slug" data-plugin-slug="' . Config::get_stellar_slug() . '"></i>';
+			$deactivate_link .= '<i class="telemetry-plugin-slug" data-plugin-slug="' . $stellar_slug . '"></i>';
 
 			// Append deactivation link.
 			$before_deactivate['deactivate'] = $deactivate_link;

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -92,6 +92,8 @@ class Template implements Template_Interface {
 		/**
 		 * Filters the "Exit Interview" modal arguments.
 		 *
+		 * Planned deprecation: 3.0.0
+		 *
 		 * @since 1.0.0
 		 * @since 2.0.0 - Added the current stellar slug.
 		 *
@@ -101,7 +103,7 @@ class Template implements Template_Interface {
 		$args = apply_filters( 'stellarwp/telemetry/' . $stellar_slug . '/exit_interview_args', $args, $stellar_slug );
 
 		/**
-		 * A more general filter to filter the "Exit Interview" modal arguments.
+		 * Filters the "Exit Interview" modal arguments.
 		 *
 		 * @since 2.0.0
 		 *

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -48,52 +48,71 @@ class Template implements Template_Interface {
 	 * Gets the arguments for configuring the "Exit Interview" modal.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0
+	 *
+	 * @param string $stellar_slug The stellar slug used when outputting the modal.
 	 *
 	 * @return array
 	 */
-	protected function get_args() {
+	protected function get_args( string $stellar_slug ) {
+
+		$args = [
+			'plugin_slug'        => $stellar_slug,
+			'plugin_logo'        => Resources::get_asset_path() . 'resources/images/stellar-logo.svg',
+			'plugin_logo_width'  => 151,
+			'plugin_logo_height' => 32,
+			'plugin_logo_alt'    => 'StellarWP Logo',
+			'heading'            => __( 'We’re sorry to see you go.', 'stellarwp-telemetry' ),
+			'intro'              => __( 'We’d love to know why you’re leaving so we can improve our plugin.', 'stellarwp-telemetry' ),
+			'uninstall_reasons'  => [
+				[
+					'uninstall_reason_id' => 'confusing',
+					'uninstall_reason'    => __( 'I couldn’t understand how to make it work.', 'stellarwp-telemetry' ),
+				],
+				[
+					'uninstall_reason_id' => 'better-plugin',
+					'uninstall_reason'    => __( 'I found a better plugin.', 'stellarwp-telemetry' ),
+				],
+				[
+					'uninstall_reason_id' => 'no-feature',
+					'uninstall_reason'    => __( 'I need a specific feature it doesn’t provide.', 'stellarwp-telemetry' ),
+				],
+				[
+					'uninstall_reason_id' => 'broken',
+					'uninstall_reason'    => __( 'The plugin doesn’t work.', 'stellarwp-telemetry' ),
+				],
+				[
+					'uninstall_reason_id' => 'other',
+					'uninstall_reason'    => __( 'Other', 'stellarwp-telemetry' ),
+					'show_comment'        => true,
+				],
+			],
+		];
+
 		/**
 		 * Filters the "Exit Interview" modal arguments.
 		 *
 		 * @since 1.0.0
+		 * @since 2.0.0 - Added the current stellar slug.
 		 *
-		 * @param array $args The arguments used to configure the modal.
+		 * @param array  $args         The arguments used to configure the modal.
+		 * @param string $stellar_slug The current stellar slug for the plugin outputting the modal.
 		 */
-		return apply_filters(
-			'stellarwp/telemetry/' . Config::get_stellar_slug() . '/exit_interview_args',
-			[
-				'plugin_slug'        => Config::get_stellar_slug(),
-				'plugin_logo'        => Resources::get_asset_path() . 'resources/images/stellar-logo.svg',
-				'plugin_logo_width'  => 151,
-				'plugin_logo_height' => 32,
-				'plugin_logo_alt'    => 'StellarWP Logo',
-				'heading'            => __( 'We’re sorry to see you go.', 'stellarwp-telemetry' ),
-				'intro'              => __( 'We’d love to know why you’re leaving so we can improve our plugin.', 'stellarwp-telemetry' ),
-				'uninstall_reasons'  => [
-					[
-						'uninstall_reason_id' => 'confusing',
-						'uninstall_reason'    => __( 'I couldn’t understand how to make it work.', 'stellarwp-telemetry' ),
-					],
-					[
-						'uninstall_reason_id' => 'better-plugin',
-						'uninstall_reason'    => __( 'I found a better plugin.', 'stellarwp-telemetry' ),
-					],
-					[
-						'uninstall_reason_id' => 'no-feature',
-						'uninstall_reason'    => __( 'I need a specific feature it doesn’t provide.', 'stellarwp-telemetry' ),
-					],
-					[
-						'uninstall_reason_id' => 'broken',
-						'uninstall_reason'    => __( 'The plugin doesn’t work.', 'stellarwp-telemetry' ),
-					],
-					[
-						'uninstall_reason_id' => 'other',
-						'uninstall_reason'    => __( 'Other', 'stellarwp-telemetry' ),
-						'show_comment'        => true,
-					],
-				],
-			]
-		);
+		$args = apply_filters( 'stellarwp/telemetry/' . $stellar_slug . '/exit_interview_args', $args, $stellar_slug );
+
+		/**
+		 * A more general filter to filter the "Exit Interview" modal arguments.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param array  $args         The arguments used to configure the modal.
+		 * @param string $stellar_slug The current stellar slug for the plugin outputting the modal.
+		 *
+		 * @return void
+		 */
+		$args = apply_filters( 'stellarwp/telemetry/exit_interview_args', $args, $stellar_slug );
+
+		return $args;
 	}
 
 	/**

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -48,7 +48,7 @@ class Template implements Template_Interface {
 	 * Gets the arguments for configuring the "Exit Interview" modal.
 	 *
 	 * @since 1.0.0
-	 * @since 2.0.0
+	 * @since 2.0.0 - Updated to accept a passed stellar slug.
 	 *
 	 * @param string $stellar_slug The stellar slug used when outputting the modal.
 	 *

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -125,7 +125,7 @@ class Template implements Template_Interface {
 	 * @return void
 	 */
 	public function render( string $stellar_slug ) {
-		load_template( dirname( dirname( __DIR__ ) ) . '/views/exit-interview.php', true, $this->get_args( $stellar_slug ) );
+		load_template( dirname( dirname( __DIR__ ) ) . '/views/exit-interview.php', false, $this->get_args( $stellar_slug ) );
 	}
 
 	/**

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -93,6 +93,7 @@ class Template implements Template_Interface {
 		 * Filters the "Exit Interview" modal arguments.
 		 *
 		 * Planned deprecation: 3.0.0
+		 * Use stellarwp/telemetry/exit_interview_args filter instead.
 		 *
 		 * @since 1.0.0
 		 * @since 2.0.0 - Added the current stellar slug.

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -101,10 +101,12 @@ class Template implements Template_Interface {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param string $stellar_slug The stellar slug to be referenced when the modal is rendered.
+	 *
 	 * @return void
 	 */
-	public function render() {
-		load_template( dirname( dirname( __DIR__ ) ) . '/views/exit-interview.php', true, $this->get_args() );
+	public function render( string $stellar_slug ) {
+		load_template( dirname( dirname( __DIR__ ) ) . '/views/exit-interview.php', true, $this->get_args( $stellar_slug ) );
 	}
 
 	/**
@@ -123,17 +125,21 @@ class Template implements Template_Interface {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param string $stellar_slug The stellar slug for which the modal should be rendered.
+	 *
 	 * @return boolean
 	 */
-	public function should_render() {
+	public function should_render( string $stellar_slug ) {
 		/**
 		 * Filters whether the "Exit Interview" modal should render.
 		 *
 		 * @since 1.0.0
+		 * @since 2.0.0 - Update to include current stellar slug.
 		 *
-		 * @param bool $should_render Whether the modal should render.
+		 * @param bool   $should_render  Whether the modal should render.
+		 * @param string $stellar_slug The current stellar slug of the plugin for which the modal is shown.
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'exit_interview_should_render', true );
+		return apply_filters( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'exit_interview_should_render', true, $stellar_slug );
 	}
 
 	/**
@@ -141,11 +147,13 @@ class Template implements Template_Interface {
 	 *
 	 * @since 1.0.0
 	 *
+	 * @param string $stellar_slug The stellar slug that could be rendered.
+	 *
 	 * @return void
 	 */
-	public function maybe_render() {
-		if ( $this->should_render() ) {
-			$this->render();
+	public function maybe_render( string $stellar_slug ) {
+		if ( $this->should_render( $stellar_slug ) ) {
+			$this->render( $stellar_slug );
 		}
 	}
 }

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -28,7 +28,13 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function register(): void {
+		/**
+		 * Planned deprecation: 3.0.0
+		 *
+		 * Use stellarwp/telemetry/optin filter instead.
+		 */
 		add_action( 'stellarwp/telemetry/' . Config::get_stellar_slug() . '/optin', [ $this, 'maybe_render_optin' ], 10, 1 );
+
 		add_action( 'stellarwp/telemetry/optin', [ $this, 'maybe_render_optin' ], 10, 1 );
 
 		add_action( 'admin_init', [ $this, 'set_optin_status' ] );

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -116,7 +116,7 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 		foreach ( Config::get_all_stellar_slugs() as $stellar_slug => $wp_slug ) {
 			// Check if plugin slug exists within array.
 			if ( ! $opt_in_status->plugin_exists( $stellar_slug ) ) {
-				$opt_in_status->add_plugin( $stellar_slug );
+				$opt_in_status->add_plugin( $stellar_slug, false, $wp_slug );
 
 				update_option( $opt_in_template->get_option_name( $stellar_slug ), '1' );
 			}

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -107,7 +107,7 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 		$opt_in_status   = $this->container->get( Status::class );
 
 		// Loop through all registered stellar slugs and add them to the optin option.
-		foreach ( Config::get_all_stellar_slugs() as $stellar_slug ) {
+		foreach ( Config::get_all_stellar_slugs() as $stellar_slug => $wp_slug ) {
 			// Check if plugin slug exists within array.
 			if ( ! $opt_in_status->plugin_exists( $stellar_slug ) ) {
 				$opt_in_status->add_plugin( $stellar_slug );

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -28,6 +28,7 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function register(): void {
+		add_action( 'stellarwp/telemetry/' . Config::get_stellar_slug() . '/optin', [ $this, 'maybe_render_optin' ], 10, 1 );
 		add_action( 'stellarwp/telemetry/optin', [ $this, 'maybe_render_optin' ], 10, 1 );
 
 		add_action( 'admin_init', [ $this, 'set_optin_status' ] );
@@ -89,7 +90,11 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 *
 	 * @return void
 	 */
-	public function maybe_render_optin( string $stellar_slug ) {
+	public function maybe_render_optin( string $stellar_slug = '' ) {
+		if ( '' === $stellar_slug ) {
+			$stellar_slug = Config::get_stellar_slug();
+		}
+
 		$this->container->get( Opt_In_Template::class )->maybe_render( $stellar_slug );
 	}
 

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -133,7 +133,7 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 
 		try {
 			$this->container->get( Telemetry::class )->register_site();
-			$this->container->get( Telemetry::class )->register_user();
+			$this->container->get( Telemetry::class )->register_user( $stellar_slug );
 		} catch ( \Error $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// We don't want to throw errors if the server cannot be reached.
 		}

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -66,15 +66,15 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 			return;
 		}
 
-		// User agreed to opt-in to Telemetry.
-		if ( 'true' === $_POST['optin-agreed'] ) {
-			$this->opt_in();
-		}
-
 		$stellar_slug = Config::get_stellar_slug();
 
 		if ( isset( $_POST['stellar_slug'] ) ) {
 			$stellar_slug = sanitize_text_field( $_POST['stellar_slug'] );
+		}
+
+		// User agreed to opt-in to Telemetry.
+		if ( 'true' === $_POST['optin-agreed'] ) {
+			$this->opt_in( $stellar_slug );
 		}
 
 		// Don't show the opt-in modal again.
@@ -121,11 +121,14 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 * Registers the site/user with the telemetry server and sets the opt-in status.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Updated to allow specifying the stellar slug.
+	 *
+	 * @param string $stellar_slug The slug to use when opting in.
 	 *
 	 * @return void
 	 */
-	public function opt_in() {
-		$this->container->get( Status::class )->set_status( true );
+	public function opt_in( string $stellar_slug ) {
+		$this->container->get( Status::class )->set_status( true, $stellar_slug );
 
 		try {
 			$this->container->get( Telemetry::class )->register_site();

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -97,15 +97,17 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function initialize_optin_option() {
-		$stellar_slug    = Config::get_stellar_slug();
 		$opt_in_template = $this->container->get( Opt_In_Template::class );
 		$opt_in_status   = $this->container->get( Status::class );
 
-		// Check if plugin slug exists within array.
-		if ( ! $opt_in_status->plugin_exists( $stellar_slug ) ) {
-			$opt_in_status->add_plugin( $stellar_slug );
+		// Loop through all registered stellar slugs and add them to the optin option.
+		foreach ( Config::get_all_stellar_slugs() as $stellar_slug ) {
+			// Check if plugin slug exists within array.
+			if ( ! $opt_in_status->plugin_exists( $stellar_slug ) ) {
+				$opt_in_status->add_plugin( $stellar_slug );
 
-			update_option( $opt_in_template->get_option_name(), '1' );
+				update_option( $opt_in_template->get_option_name(), '1' );
+			}
 		}
 	}
 

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -28,7 +28,10 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function register(): void {
-		add_action( 'stellarwp/telemetry/' . Config::get_stellar_slug() . '/optin', [ $this, 'maybe_render_optin' ] );
+		foreach ( Config::get_all_stellar_slugs() as $slug ) {
+			add_action( 'stellarwp/telemetry/' . $slug . '/optin', [ $this, 'maybe_render_optin' ] );
+		}
+
 		add_action( 'admin_init', [ $this, 'set_optin_status' ] );
 		add_action( 'init', [ $this, 'initialize_optin_option' ] );
 	}

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -71,8 +71,14 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 			$this->opt_in();
 		}
 
+		$stellar_slug = Config::get_stellar_slug();
+
+		if ( isset( $_POST['stellar_slug'] ) ) {
+			$stellar_slug = sanitize_text_field( $_POST['stellar_slug'] );
+		}
+
 		// Don't show the opt-in modal again.
-		update_option( $this->container->get( Opt_In_Template::class )->get_option_name(), '0' );
+		update_option( $this->container->get( Opt_In_Template::class )->get_option_name( $stellar_slug ), '0' );
 	}
 
 	/**
@@ -106,7 +112,7 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 			if ( ! $opt_in_status->plugin_exists( $stellar_slug ) ) {
 				$opt_in_status->add_plugin( $stellar_slug );
 
-				update_option( $opt_in_template->get_option_name(), '1' );
+				update_option( $opt_in_template->get_option_name( $stellar_slug ), '1' );
 			}
 		}
 	}

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -28,9 +28,7 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function register(): void {
-		foreach ( Config::get_all_stellar_slugs() as $slug ) {
-			add_action( 'stellarwp/telemetry/' . $slug . '/optin', [ $this, 'maybe_render_optin' ] );
-		}
+		add_action( 'stellarwp/telemetry/optin', [ $this, 'maybe_render_optin' ], 10, 1 );
 
 		add_action( 'admin_init', [ $this, 'set_optin_status' ] );
 		add_action( 'init', [ $this, 'initialize_optin_option' ] );
@@ -85,11 +83,14 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 * Renders the opt-in modal if it should be rendered.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Update to handle rendering multiple modals.
+	 *
+	 * @param string $stellar_slug The stellar slug to use in determining when and how the modal is displayed.
 	 *
 	 * @return void
 	 */
-	public function maybe_render_optin() {
-		$this->container->get( Opt_In_Template::class )->maybe_render();
+	public function maybe_render_optin( string $stellar_slug ) {
+		$this->container->get( Opt_In_Template::class )->maybe_render( $stellar_slug );
 	}
 
 	/**

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -188,7 +188,7 @@ class Opt_In_Template implements Template_Interface {
 	 * @return void
 	 */
 	public function maybe_render() {
-		foreach ( Config::get_all_stellar_slugs() as $stellar_slug ) {
+		foreach ( Config::get_all_stellar_slugs() as $stellar_slug => $wp_slug ) {
 			if ( $this->should_render( $stellar_slug ) ) {
 				$this->render( $stellar_slug );
 			}

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -111,6 +111,8 @@ class Opt_In_Template implements Template_Interface {
 		/**
 		 * Filters the arguments for rendering the Opt-In modal.
 		 *
+		 * Planned Deprecation: 3.0.0
+		 *
 		 * @since 1.0.0
 		 *
 		 * @param array $optin_args

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -56,10 +56,13 @@ class Opt_In_Template implements Template_Interface {
 	 * Gets the arguments for configuring how the Opt-In modal is rendered.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Updated to handle passed in stellar slug
+	 *
+	 * @param string $stellar_slug The slug to use when configuring the modal args.
 	 *
 	 * @return array
 	 */
-	protected function get_args() {
+	protected function get_args( string $stellar_slug ) {
 
 		$optin_args = [
 			'plugin_logo'           => Resources::get_asset_path() . 'resources/images/stellar-logo.svg',
@@ -67,7 +70,7 @@ class Opt_In_Template implements Template_Interface {
 			'plugin_logo_height'    => 32,
 			'plugin_logo_alt'       => 'StellarWP Logo',
 			'plugin_name'           => 'StellarWP',
-			'plugin_slug'           => Config::get_stellar_slug(),
+			'plugin_slug'           => $stellar_slug,
 			'user_name'             => wp_get_current_user()->display_name,
 			'permissions_url'       => '#',
 			'tos_url'               => '#',
@@ -98,42 +101,68 @@ class Opt_In_Template implements Template_Interface {
 		/**
 		 * Filters the arguments for rendering the Opt-In modal.
 		 *
+		 * @since 2.0.0
+		 *
+		 * @param array $optin_args
+		 * @param string $stellar_slug
+		 */
+		$optin_args = apply_filters( 'stellarwp/telemetry/optin_args', $optin_args, $stellar_slug );
+
+		/**
+		 * Filters the arguments for rendering the Opt-In modal.
+		 *
 		 * @since 1.0.0
 		 *
 		 * @param array $optin_args
 		 */
-		return apply_filters( 'stellarwp/telemetry/' . Config::get_stellar_slug() . '/optin_args', $optin_args );
+		$optin_args = apply_filters( 'stellarwp/telemetry/' . $stellar_slug . '/optin_args', $optin_args );
+
+		return $optin_args;
 	}
 
 	/**
 	 * @inheritDoc
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Update to handle passed in stellar slug.
+	 *
+	 * @param string $stellar_slug The slug to render the modal with.
 	 *
 	 * @return void
 	 */
-	public function render() {
-		load_template( dirname( dirname( __DIR__ ) ) . '/views/optin.php', true, $this->get_args() );
+	public function render( string $stellar_slug ) {
+		load_template( dirname( dirname( __DIR__ ) ) . '/views/optin.php', true, $this->get_args( $stellar_slug ) );
 	}
 
 	/**
 	 * Gets the option that determines if the modal should be rendered.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Update to handle passed in stellar_slug.
+	 *
+	 * @param string $stellar_slug The current stellar slug to be used in the option name.
 	 *
 	 * @return string
 	 */
-	public function get_option_name() {
+	public function get_option_name( string $stellar_slug ) {
+		$option_name = sprintf(
+			'stellarwp_telemetry_%s_show_optin',
+			$stellar_slug
+		);
+
 		/**
 		 * Filters the name of the option stored in the options table.
 		 *
 		 * @since 1.0.0
+		 * @since 2.0.0 - Update to pass stellar slug for checking the current filter context.
 		 *
-		 * @param string $show_optin_option_name
+		 * @param string $option_name
+		 * @param string $stellar_slug The current stellar slug.
 		 */
 		return apply_filters(
 			'stellarwp/telemetry/' . Config::get_hook_prefix() . 'show_optin_option_name',
-			'stellarwp_telemetry_' . Config::get_stellar_slug() . '_show_optin'
+			$option_name,
+			$stellar_slug
 		);
 	}
 
@@ -141,11 +170,14 @@ class Opt_In_Template implements Template_Interface {
 	 * Helper function to determine if the modal should be rendered.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - update to handle passed in stellar_slug.
+	 *
+	 * @param string $stellar_slug The stellar slug to get the option name for.
 	 *
 	 * @return boolean
 	 */
-	public function should_render() {
-		return (bool) get_option( $this->get_option_name(), false );
+	public function should_render( string $stellar_slug ) {
+		return (bool) get_option( $this->get_option_name( $stellar_slug ), false );
 	}
 
 	/**
@@ -156,8 +188,10 @@ class Opt_In_Template implements Template_Interface {
 	 * @return void
 	 */
 	public function maybe_render() {
-		if ( $this->should_render() ) {
-			$this->render();
+		foreach ( Config::get_all_stellar_slugs() as $stellar_slug ) {
+			if ( $this->should_render( $stellar_slug ) ) {
+				$this->render( $stellar_slug );
+			}
 		}
 	}
 

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -131,7 +131,7 @@ class Opt_In_Template implements Template_Interface {
 	 * @return void
 	 */
 	public function render( string $stellar_slug ) {
-		load_template( dirname( dirname( __DIR__ ) ) . '/views/optin.php', true, $this->get_args( $stellar_slug ) );
+		load_template( dirname( dirname( __DIR__ ) ) . '/views/optin.php', false, $this->get_args( $stellar_slug ) );
 	}
 
 	/**
@@ -184,14 +184,15 @@ class Opt_In_Template implements Template_Interface {
 	 * Renders the modal if it should be rendered.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Add ability to render multiple modals.
+	 *
+	 * @param string $stellar_slug The stellar slug for which the modal should be rendered.
 	 *
 	 * @return void
 	 */
-	public function maybe_render() {
-		foreach ( Config::get_all_stellar_slugs() as $stellar_slug => $wp_slug ) {
-			if ( $this->should_render( $stellar_slug ) ) {
-				$this->render( $stellar_slug );
-			}
+	public function maybe_render( string $stellar_slug ) {
+		if ( $this->should_render( $stellar_slug ) ) {
+			$this->render( $stellar_slug );
 		}
 	}
 

--- a/src/Telemetry/Opt_In/Status.php
+++ b/src/Telemetry/Opt_In/Status.php
@@ -214,15 +214,22 @@ class Status {
 	 * Sets the opt-in status option for the site.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Updated to allow defined stellar_slug.
 	 *
-	 * @param boolean $status The status to set (Active = 1, Inactive = 2, Mixed = 3).
+	 * @param boolean $status       The status to set (Active = 1, Inactive = 2, Mixed = 3).
+	 * @param string  $stellar_slug The stellar_slug to set the status of.
 	 *
 	 * @return boolean
 	 */
-	public function set_status( bool $status ) {
+	public function set_status( bool $status, string $stellar_slug = '' ) {
+		// If no stellar slug is passed, use the singular value.
+		if ( '' === $stellar_slug ) {
+			$stellar_slug = Config::get_stellar_slug();
+		}
+
 		$option = $this->get_option();
 
-		$option['plugins'][ Config::get_stellar_slug() ]['optin'] = $status;
+		$option['plugins'][ $stellar_slug ]['optin'] = $status;
 
 		return update_option( $this->get_option_name(), $option );
 	}

--- a/src/Telemetry/Opt_In/Status.php
+++ b/src/Telemetry/Opt_In/Status.php
@@ -141,16 +141,21 @@ class Status {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string  $stellar_slug The unique slug identifier for the plugin.
-	 * @param boolean $status       The opt-in status for the plugin.
+	 * @param string  $stellar_slug    The unique slug identifier for the plugin.
+	 * @param boolean $status          The opt-in status for the plugin.
+	 * @param string  $plugin_basename The specific basename for the plugin.
 	 *
 	 * @return boolean
 	 */
-	public function add_plugin( string $stellar_slug, bool $status = false ) {
+	public function add_plugin( string $stellar_slug, bool $status = false, string $plugin_basename = '' ) {
 		$option = $this->get_option();
 
+		if ( '' === $plugin_basename ) {
+			$plugin_basename = Config::get_container()->get( Core::PLUGIN_BASENAME );
+		}
+
 		$option['plugins'][ $stellar_slug ] = [
-			'wp_slug' => Config::get_container()->get( Core::PLUGIN_BASENAME ),
+			'wp_slug' => $plugin_basename,
 			'optin'   => $status,
 		];
 

--- a/src/Telemetry/Uninstall.php
+++ b/src/Telemetry/Uninstall.php
@@ -24,22 +24,25 @@ class Uninstall {
 	 * Removes necessary items from the options table.
 	 *
 	 * @since 1.0.0
+	 * @since 2.0.0 - Update to handle multiple stellar_slugs.
 	 *
-	 * @param string $stellar_slug The slug for the plugin being deleted.
+	 * @param string[] $stellar_slugs The slugs for the plugin being deleted.
 	 *
 	 * @return void
 	 */
-	public static function run( string $stellar_slug ) {
+	public static function run( array $stellar_slugs ) {
 		$opt_in_status = new Status();
 
-		if ( $opt_in_status->plugin_exists( $stellar_slug ) ) {
-			$opt_in_status->remove_plugin( $stellar_slug );
-		}
+		foreach ( $stellar_slugs as $slug ) {
+			if ( $opt_in_status->plugin_exists( $slug ) ) {
+				$opt_in_status->remove_plugin( $slug );
+			}
 
-		$optin_option_name = 'stellarwp_telemetry_' . $stellar_slug . '_show_optin';
+			$optin_option_name = 'stellarwp_telemetry_' . $slug . '_show_optin';
 
-		if ( get_option( $optin_option_name ) !== false ) {
-			delete_option( $optin_option_name );
+			if ( get_option( $optin_option_name ) !== false ) {
+				delete_option( $optin_option_name );
+			}
 		}
 
 		// If this is the last plugin in the optin option, let's remove the option entirely.

--- a/src/Telemetry/Uninstall.php
+++ b/src/Telemetry/Uninstall.php
@@ -24,25 +24,22 @@ class Uninstall {
 	 * Removes necessary items from the options table.
 	 *
 	 * @since 1.0.0
-	 * @since 2.0.0 - Update to handle multiple stellar_slugs.
 	 *
-	 * @param string[] $stellar_slugs The slugs for the plugin being deleted.
+	 * @param string $stellar_slug The slug for the plugin being deleted.
 	 *
 	 * @return void
 	 */
-	public static function run( array $stellar_slugs ) {
+	public static function run( $stellar_slug ) {
 		$opt_in_status = new Status();
 
-		foreach ( $stellar_slugs as $slug ) {
-			if ( $opt_in_status->plugin_exists( $slug ) ) {
-				$opt_in_status->remove_plugin( $slug );
-			}
+		if ( $opt_in_status->plugin_exists( $stellar_slug ) ) {
+			$opt_in_status->remove_plugin( $stellar_slug );
+		}
 
-			$optin_option_name = 'stellarwp_telemetry_' . $slug . '_show_optin';
+		$optin_option_name = 'stellarwp_telemetry_' . $stellar_slug . '_show_optin';
 
-			if ( get_option( $optin_option_name ) !== false ) {
-				delete_option( $optin_option_name );
-			}
+		if ( get_option( $optin_option_name ) !== false ) {
+			delete_option( $optin_option_name );
 		}
 
 		// If this is the last plugin in the optin option, let's remove the option entirely.

--- a/src/views/optin.php
+++ b/src/views/optin.php
@@ -55,6 +55,7 @@
 		<footer>
 			<form method="post" action="" data-js="optin-form">
 				<input type="hidden" name="action" value="stellarwp-telemetry">
+				<input type="hidden" name="stellar_slug" value="<?php echo esc_attr( $args['plugin_slug'] ); ?>">
 				<?php wp_nonce_field( 'stellarwp-telemetry' ); ?>
 				<button class="stellarwp-telemetry-btn-primary" data-js="form-submit" type="submit" name="optin-agreed" value="true">
 					<?php echo esc_html__( 'Allow & Continue', 'stellarwp-telemetry' ); ?>


### PR DESCRIPTION
This is a major upgrade that lets plugins define multiple `stellar_slugs`. The use case came from TEC where they load the library from a shared library for several of their plugins. Registering multiple stellar_slugs will allow TEC to manually add opt-in modals for each add-on using the shared library.

Here's a walkthrough screencast of the changes: http://p.tri.be/v/oQXjX4

## Progress Tracking
- [x] Update Modal rendering to handle multiple stellar_slugs
- [x] Update Modal arguments to handle passed stellar_slug
- [x] Update `Status::set_status()` ~~and `Status::get_status()`~~ to handle multiple stellar_slugs (add slug parameter to define which slug it's updating/~~getting~~)
- [x] Update `Exit_Interview` arguments to handle passing stellar_slug
- [x] Update `Exit_Interview::plugin_action_links()` to output deactivate link for each plugin utilizing a specific stellar_slug
- [x] Update `Telemetry::get_user_details()` to handle multiple stellar_slugs
- [x] Update Telemetry Starter settings page to show/control each slug's modal
- [x] Update plugin uninstall to handle multiple stellar_slugs
- [x] Add Documentation for all new/changed features