### PR TITLE
Prevent fatal error if parent plugin is deleted without activating

### DIFF
--- a/src/Telemetry/Uninstall.php
+++ b/src/Telemetry/Uninstall.php
@@ -57,7 +57,7 @@ class Uninstall {
 		$optin = get_option( 'stellarwp_telemetry' );
 
 		// Bail if option has more than 'token' in the array.
-		if ( $optin === false || count( $optin ) > 1 ) {
+		if ( false === $optin || count( $optin ) > 1 ) {
 			return;
 		}
 

--- a/src/Telemetry/Uninstall.php
+++ b/src/Telemetry/Uninstall.php
@@ -57,7 +57,7 @@ class Uninstall {
 		$optin = get_option( 'stellarwp_telemetry' );
 
 		// Bail if option has more than 'token' in the array.
-		if ( count( $optin ) > 1 ) {
+		if ( $optin === false || count( $optin ) > 1 ) {
 			return;
 		}
 

--- a/src/Telemetry/Uninstall.php
+++ b/src/Telemetry/Uninstall.php
@@ -56,7 +56,7 @@ class Uninstall {
 	public static function maybe_remove_optin_option() {
 		$optin = get_option( 'stellarwp_telemetry' );
 
-		// Bail if option has more than 'token' in the array.
+		// Bail if option is not set or has more than 'token' in the array.
 		if ( false === $optin || count( $optin ) > 1 ) {
 			return;
 		}


### PR DESCRIPTION
If the parent plugin is installed, but not activated, `stellarwp_telemetry` is not set. When deleting the plugin, the default value of `false` is passed to the `count()` function which will throw a warning on php 7.2+ and fatal error on 8.0+.

**Steps to recreate**
- Install Kadence Blocks (3.1.*) on a site without a `stellarwp_telemetry` entry in options table
- Do not activate plugin
- Attempt to delete plugin via wp-admin