### PR TITLE
[FRAME-176]: Delay Events Until Shutdown

### DIFF
--- a/dev/public/wp-content/plugins/library-testing/library-testing.php
+++ b/dev/public/wp-content/plugins/library-testing/library-testing.php
@@ -31,3 +31,43 @@ add_action(
 		do_action( 'stellarwp/telemetry/optin', 'telemetry-library' );
 	}
 );
+
+// If the 'Send Events' link was used, send some test events once.
+add_action(
+	'init',
+	function() {
+		if ( ! isset( $_GET['send-events'] ) ) {
+			return;
+		}
+
+		do_action( 'stellarwp/telemetry/telemetry-prefix/event', 'opt-in', [ 'one' => 1 ] );
+		do_action( 'stellarwp/telemetry/telemetry-prefix/event', 'create-post', [ 'post-title' => 'This is my first post!' ] );
+		do_action( 'stellarwp/telemetry/telemetry-prefix/event', 'opt-out', [ 'one' => 1 ] );
+
+		wp_safe_redirect( remove_query_arg( 'send-events' ) );
+		exit;
+	}
+);
+
+/**
+ * Adds a helper link to the admin bar for sending a group of events.
+ *
+ * @param WP_Admin_Bar $admin_bar The adminbar class.
+ *
+ * @return void
+ */
+function add_event_send_link( $admin_bar ) {
+	global $wp;
+
+	$admin_bar->add_menu(
+		[
+			'id'    => 'send-events',
+			'title' => 'Send Events',
+			'href'  => add_query_arg( [ 'send-events' => true ], home_url( $wp->request ) ),
+			'meta'  => [
+				'title' => __( 'Send Events' ),
+			],
+		]
+	);
+}
+add_action( 'admin_bar_menu', 'add_event_send_link', 100, 1 );

--- a/dev/public/wp-content/plugins/library-testing/library-testing.php
+++ b/dev/public/wp-content/plugins/library-testing/library-testing.php
@@ -36,7 +36,7 @@ add_action(
 add_action(
 	'init',
 	function() {
-		if ( ! isset( $_GET['send-events'] ) ) {
+		if ( ! isset( $_GET['send-events'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 

--- a/src/Telemetry/Events/Event.php
+++ b/src/Telemetry/Events/Event.php
@@ -85,6 +85,30 @@ class Event {
 	}
 
 	/**
+	 * Send batched events.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $events An array of stored events to send to the telemetry server.
+	 *
+	 * @return bool
+	 */
+	public function send_batch( array $events ) {
+		$data = [
+			'token'  => $this->telemetry->get_token(),
+			'events' => $events,
+		];
+
+		$response = $this->telemetry->send( $data, $this->get_url() );
+
+		if ( ! isset( $response['status'] ) ) {
+			return false;
+		}
+
+		return boolval( $response['status'] );
+	}
+
+	/**
 	 * Gets the url used for sending events.
 	 *
 	 * @since 2.1.0

--- a/src/Telemetry/Events/Event.php
+++ b/src/Telemetry/Events/Event.php
@@ -22,6 +22,13 @@ use StellarWP\Telemetry\Telemetry\Telemetry;
 class Event {
 
 	/**
+	 * The hook name for sending events asyncronously.
+	 *
+	 * @since TBD
+	 */
+	public const AJAX_ACTION = 'stellarwp_telemetry_send_event';
+
+	/**
 	 * An instance of the Telemetry class.
 	 *
 	 * @since 2.1.0

--- a/src/Telemetry/Events/Event_Subscriber.php
+++ b/src/Telemetry/Events/Event_Subscriber.php
@@ -30,7 +30,7 @@ class Event_Subscriber extends Abstract_Subscriber {
 	 */
 	public function register() {
 		add_action( 'shutdown', [ $this, 'send_cached_events' ] );
-		add_action( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'event', [ $this, 'cache_event' ], 10, 3 );
+		add_action( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'event', [ $this, 'cache_event' ], 10, 2 );
 		add_action( 'wp_ajax_' . Event::AJAX_ACTION, [ $this, 'send_events' ], 10, 1 );
 		add_action( 'wp_ajax_nopriv_' . Event::AJAX_ACTION, [ $this, 'send_events' ], 10, 1 );
 	}

--- a/src/Telemetry/Events/Event_Subscriber.php
+++ b/src/Telemetry/Events/Event_Subscriber.php
@@ -102,9 +102,12 @@ class Event_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function send_event() {
+		// Get the passed event array.
 		$event = filter_input( INPUT_POST, 'event', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY ); // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.RestrictedFilter
-		$name  = key( $event );
-		$data  = $event[ $name ];
+		// Get the name of the event from the key of the array.
+		$name = key( $event );
+		// Set the data for the event.
+		$data = (array) $event[ $name ];
 
 		$this->container->get( Event::class )->send( $name, $data );
 	}

--- a/src/Telemetry/Events/Event_Subscriber.php
+++ b/src/Telemetry/Events/Event_Subscriber.php
@@ -69,7 +69,7 @@ class Event_Subscriber extends Abstract_Subscriber {
 			return;
 		}
 
-		$url = admin_url( 'admin-ajax.php?XDEBUG_SESSION_START=1' );
+		$url = admin_url( 'admin-ajax.php' );
 
 		$events = $this->container->get( 'events' );
 

--- a/src/Telemetry/Events/Event_Subscriber.php
+++ b/src/Telemetry/Events/Event_Subscriber.php
@@ -9,6 +9,7 @@
 
 namespace StellarWP\Telemetry\Events;
 
+use StellarWP\Telemetry\Config;
 use StellarWP\Telemetry\Contracts\Abstract_Subscriber;
 
 /**
@@ -28,19 +29,83 @@ class Event_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function register() {
-		add_action( 'stellarwp/telemetry/event', [ $this, 'send_event' ], 10, 2 );
+		add_action( 'shutdown', [ $this, 'send_cached_events' ] );
+		add_action( 'stellarwp/telemetry/' . Config::get_hook_prefix() . 'event', [ $this, 'cache_event' ], 10, 2 );
+		add_action( 'wp_ajax_' . Event::AJAX_ACTION, [ $this, 'send_event' ], 10, 1 );
+		add_action( 'wp_ajax_nopriv_' . Event::AJAX_ACTION, [ $this, 'send_event' ], 10, 1 );
 	}
 
 	/**
-	 * Sends an event request to the Telemetry server.
+	 * Caches an event to be sent during shutdown.
 	 *
-	 * @since 2.1.0
+	 * @since TBD
 	 *
-	 * @param string $name The name of the event to send.
-	 * @param array  $data Additional information to send with the event.
+	 * @param string $name The name of the event.
+	 * @param array  $data The data sent along with the event.
+	 *
+	 * @return void
 	 */
-	public function send_event( string $name, array $data = [] ) {
-		$this->container->get( Event::class )->send( $name, $data );
+	public function cache_event( $name, $data ) {
+		$events = [];
+
+		if ( $this->container->has( 'events' ) ) {
+			$events = $this->container->get( 'events' );
+		}
+
+		$events[] = [ $name => $data ];
+
+		$this->container->bind( 'events', $events );
 	}
 
+	/**
+	 * Sends the events that have been stored for the current request.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function send_cached_events() {
+		if ( ! $this->container->has( 'events' ) ) {
+			return;
+		}
+
+		$url = admin_url( 'admin-ajax.php?XDEBUG_SESSION_START=1' );
+
+		$events = $this->container->get( 'events' );
+
+		// Kick off asyncronous requests for each cached event.
+		foreach ( $events as $key => $event ) {
+			// Remove each event as they are sent.
+			unset( $events[ $key ] );
+
+			wp_remote_post(
+				$url,
+				[
+					'blocking'  => false,
+					'sslverify' => false,
+					'body'      => [
+						'action' => Event::AJAX_ACTION,
+						'event'  => $event,
+					],
+				]
+			);
+		}
+
+		$this->container->bind( 'events', [] );
+	}
+
+	/**
+	 * Send the event to the telemetry server.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function send_event() {
+		$event = filter_input( INPUT_POST, 'event', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY ); // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.RestrictedFilter
+		$name  = key( $event );
+		$data  = $event[ $name ];
+
+		$this->container->get( Event::class )->send( $name, $data );
+	}
 }


### PR DESCRIPTION
This adds functionality to cache all events for the request until the `shutdown` action. Then during `shutdown` each event request is sent in a similar fashion to how we send the telemetry data.
1. A request is sent to the ajax endpoint
2. A new request is created during the ajax request to actually send the event to the server

This should keep the user from needing to wait for the requests to send, but it does not prevent the server from being overloaded if a plugin sends a large number of requests on each page load.