### PR TITLE
Store the opt-in user details in the options

### DIFF
--- a/src/Telemetry/Opt_In/Status.php
+++ b/src/Telemetry/Opt_In/Status.php
@@ -20,10 +20,11 @@ use StellarWP\Telemetry\Core;
  * @package StellarWP\Telemetry
  */
 class Status {
-	public const OPTION_NAME     = 'stellarwp_telemetry';
-	public const STATUS_ACTIVE   = 1;
-	public const STATUS_INACTIVE = 2;
-	public const STATUS_MIXED    = 3;
+	public const OPTION_NAME           = 'stellarwp_telemetry';
+	public const OPTION_NAME_USER_INFO = 'stellarwp_telemetry_user_info';
+	public const STATUS_ACTIVE         = 1;
+	public const STATUS_INACTIVE       = 2;
+	public const STATUS_MIXED          = 3;
 
 	/**
 	 * Gets the option name used to store the opt-in status.

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -89,8 +89,12 @@ class Telemetry {
 			$stellar_slug = Config::get_stellar_slug();
 		}
 
+		$user_details = $this->get_user_details( $stellar_slug );
+
 		try {
-			$this->send( $this->get_user_details( $stellar_slug ), Config::get_server_url() . '/opt-in', false );
+			$this->send( $user_details, Config::get_server_url() . '/opt-in', false );
+			// Store the user info in the options table.
+			update_option( Status::OPTION_NAME_USER_INFO, $user_details, false );
 		} catch ( \Error $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// We don't want to throw errors if the server fails.
 		}


### PR DESCRIPTION
This will help provide a point of reference if the user opt-in needs to be sent again or we need it for some other purpose down the road.

![The new option listed in the option table](https://cdn-std.droplr.net/files/acc_1163679/HAagUd)

For reference, the value stored in the database is the same json-encoded payload sent to the server during user opt-in:
```JSON
{
  "name":"admin",
  "email":"admin@telemetry-library.lndo.site",
  "plugin_slug":"telemetry-library"
}
```