### PR TITLE
[FRAME-170]: Add functionality to pass opt_in_text to opt-in

### DIFF
--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -77,9 +77,15 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 			$stellar_slug = sanitize_text_field( $_POST['stellar_slug'] );
 		}
 
+		$opt_in_text = '';
+
+		if ( isset( $_POST['opt_in_text'] ) ) {
+			$opt_in_text = sanitize_text_field( $_POST['opt_in_text'] );
+		}
+
 		// User agreed to opt-in to Telemetry.
 		if ( 'true' === $_POST['optin-agreed'] ) {
-			$this->opt_in( $stellar_slug );
+			$this->opt_in( $stellar_slug, $opt_in_text );
 		}
 
 		// Don't show the opt-in modal again.
@@ -134,17 +140,19 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 *
 	 * @since 1.0.0
 	 * @since 2.0.0 - Updated to allow specifying the stellar slug.
+	 * @since TBD - Updated to add opt-in text.
 	 *
 	 * @param string $stellar_slug The slug to use when opting in.
+	 * @param string $opt_in_text  The text displayed to the user when they agreed to opt-in.
 	 *
 	 * @return void
 	 */
-	public function opt_in( string $stellar_slug ) {
+	public function opt_in( string $stellar_slug, string $opt_in_text = '' ) {
 		$this->container->get( Status::class )->set_status( true, $stellar_slug );
 
 		try {
 			$this->container->get( Telemetry::class )->register_site();
-			$this->container->get( Telemetry::class )->register_user( $stellar_slug );
+			$this->container->get( Telemetry::class )->register_user( $stellar_slug, $opt_in_text );
 		} catch ( \Error $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// We don't want to throw errors if the server cannot be reached.
 		}

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -85,18 +85,8 @@ class Opt_In_Template implements Template_Interface {
 			__( 'We hope you love %s.', 'stellarwp-telemetry' ),
 			$optin_args['plugin_name']
 		);
-		$optin_args['intro'] = sprintf(
-			// Translators: The user name and the plugin name.
-			__(
-				'Hi, %1$s! This is an invitation to help our StellarWP community.
-				If you opt-in, some data about your usage of %2$s and future StellarWP Products will be shared with our teams (so they can work their butts off to improve).
-				We will also share some helpful info on WordPress, and our products from time to time.
-				And if you skip this, that’s okay! Our products still work just fine.',
-				'stellarwp-telemetry'
-			),
-			$optin_args['user_name'],
-			$optin_args['plugin_name']
-		);
+
+		$optin_args['intro'] = $this->get_intro( $optin_args['user_name'], $optin_args['plugin_name'] );
 
 		/**
 		 * Filters the arguments for rendering the Opt-In modal.
@@ -229,5 +219,28 @@ class Opt_In_Template implements Template_Interface {
 		}
 
 		return $opted_in_plugins;
+	}
+
+	/**
+	 * Gets the primary message displayed on the opt-in modal.
+	 *
+	 * @param string $user_name   The display name of the user.
+	 * @param string $plugin_name The name of the plugin.
+	 *
+	 * @return string
+	 */
+	public function get_intro( $user_name, $plugin_name ) {
+		return sprintf(
+			// Translators: The user name and the plugin name.
+			esc_html__(
+				'Hi, %1$s! This is an invitation to help our StellarWP community.
+				If you opt-in, some data about your usage of %2$s and future StellarWP Products will be shared with our teams (so they can work their butts off to improve).
+				We will also share some helpful info on WordPress, and our products from time to time.
+				And if you skip this, that’s okay! Our products still work just fine.',
+				'stellarwp-telemetry'
+			),
+			$user_name,
+			$plugin_name
+		);
 	}
 }

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -62,7 +62,7 @@ class Opt_In_Template implements Template_Interface {
 	 *
 	 * @return array
 	 */
-	protected function get_args( string $stellar_slug ) {
+	public function get_args( string $stellar_slug ) {
 
 		$optin_args = [
 			'plugin_logo'           => Resources::get_asset_path() . 'resources/images/stellar-logo.svg',

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -339,6 +339,7 @@ class Telemetry {
 	 * @since 2.0.0 - Add support for passing stellar_slug directly.
 	 *
 	 * @param string $stellar_slug The plugin slug to pass to the server when registering a site user.
+	 * @param string $opt_in_text  The opt-in text displayed to the user when they agreed to share their data.
 	 *
 	 * @return array
 	 */

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -82,20 +82,19 @@ class Telemetry {
 	 * @since 2.0.0 - Add support for setting the stellar slug.
 	 *
 	 * @param string $stellar_slug The slug to pass to the server when registering the site user.
+	 * @param string $opt_in_text  The opt-in text displayed to the user when they agreed to share their data.
 	 *
 	 * @return void
 	 */
-	public function register_user( string $stellar_slug = '' ) {
+	public function register_user( string $stellar_slug = '', string $opt_in_text = '' ) {
 		if ( '' === $stellar_slug ) {
 			$stellar_slug = Config::get_stellar_slug();
 		}
 
-		$user_details = $this->get_user_details( $stellar_slug );
+		$user_details = $this->get_user_details( $stellar_slug, $opt_in_text );
 
 		try {
 			$this->send( $user_details, Config::get_server_url() . '/opt-in', false );
-			// Store the user info in the options table.
-			update_option( Status::OPTION_NAME_USER_INFO, $user_details, false );
 		} catch ( \Error $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// We don't want to throw errors if the server fails.
 		}
@@ -343,7 +342,7 @@ class Telemetry {
 	 *
 	 * @return array
 	 */
-	protected function get_user_details( string $stellar_slug = '' ) {
+	protected function get_user_details( string $stellar_slug = '', string $opt_in_text = '' ) {
 		if ( '' == $stellar_slug ) {
 			$stellar_slug = Config::get_stellar_slug();
 		}
@@ -355,7 +354,7 @@ class Telemetry {
 			'name'        => $user->display_name,
 			'email'       => $user->user_email,
 			'plugin_slug' => $stellar_slug,
-			'opt_in_text' => $template->get_intro( $user->display_name, $stellar_slug ),
+			'opt_in_text' => $opt_in_text,
 		];
 
 		/**

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -348,15 +348,14 @@ class Telemetry {
 			$stellar_slug = Config::get_stellar_slug();
 		}
 
-		$modal_args = Config::get_container()->get( Opt_In_Template::class )->get_args( $stellar_slug );
-
-		$user = wp_get_current_user();
+		$user     = wp_get_current_user();
+		$template = Config::get_container()->get( Opt_In_Template::class );
 
 		$args = [
 			'name'        => $user->display_name,
 			'email'       => $user->user_email,
 			'plugin_slug' => $stellar_slug,
-			'opt_in_text' => $modal_args['intro'],
+			'opt_in_text' => $template->get_intro( $user->display_name, $stellar_slug ),
 		];
 
 		/**

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -11,6 +11,7 @@ namespace StellarWP\Telemetry\Telemetry;
 
 use StellarWP\Telemetry\Config;
 use StellarWP\Telemetry\Contracts\Data_Provider;
+use StellarWP\Telemetry\Opt_In\Opt_In_Template;
 use StellarWP\Telemetry\Opt_In\Status;
 
 /**
@@ -347,12 +348,15 @@ class Telemetry {
 			$stellar_slug = Config::get_stellar_slug();
 		}
 
+		$modal_args = Config::get_container()->get( Opt_In_Template::class )->get_args( $stellar_slug );
+
 		$user = wp_get_current_user();
 
 		$args = [
 			'name'        => $user->display_name,
 			'email'       => $user->user_email,
 			'plugin_slug' => $stellar_slug,
+			'opt_in_text' => $modal_args['intro'],
 		];
 
 		/**

--- a/src/views/optin.php
+++ b/src/views/optin.php
@@ -56,6 +56,7 @@
 			<form method="post" action="" data-js="optin-form">
 				<input type="hidden" name="action" value="stellarwp-telemetry">
 				<input type="hidden" name="stellar_slug" value="<?php echo esc_attr( $args['plugin_slug'] ); ?>">
+				<input type="hidden" name="opt_in_text" value="<?php echo esc_attr( $args['intro'] ); ?>">
 				<?php wp_nonce_field( 'stellarwp-telemetry' ); ?>
 				<button class="stellarwp-telemetry-btn-primary" data-js="form-submit" type="submit" name="optin-agreed" value="true">
 					<?php echo esc_html__( 'Allow & Continue', 'stellarwp-telemetry' ); ?>

--- a/tests/wpunit/TemplateTest.php
+++ b/tests/wpunit/TemplateTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use Codeception\TestCase\WPTestCase;
+use StellarWP\Telemetry\Admin\Resources;
+use StellarWP\Telemetry\Opt_In\Opt_In_Template;
+use StellarWP\Telemetry\Opt_In\Status;
+use StellarWP\Telemetry\Tests\Support\Traits\With_Test_Container;
+use StellarWP\Telemetry\Tests\Support\Traits\With_Uopz;
+
+class TemplateTest extends WPTestCase {
+
+	use With_Test_Container;
+	use With_Uopz;
+
+	public function get_default_template_data() {
+		return [
+			'plugin_logo'           => Resources::get_asset_path() . 'resources/images/stellar-logo.svg',
+			'plugin_logo_width'     => 151,
+			'plugin_logo_height'    => 32,
+			'plugin_logo_alt'       => 'StellarWP Logo',
+			'plugin_name'           => 'StellarWP',
+			'plugin_slug'           => 'telemetry-library',
+			'user_name'             => 'admin',
+			'permissions_url'       => '#',
+			'tos_url'               => '#',
+			'privacy_url'           => 'https://stellarwp.com/privacy-policy/',
+			'opted_in_plugins_text' => 'See which plugins you have opted in to tracking for',
+			'opted_in_plugins'      => [],
+			'heading'               => 'We hope you love StellarWP.',
+			'intro'                 => 'Hi, admin! This is an invitation to help our StellarWP community.
+				If you opt-in, some data about your usage of StellarWP and future StellarWP Products will be shared with our teams (so they can work their butts off to improve).
+				We will also share some helpful info on WordPress, and our products from time to time.
+				And if you skip this, that’s okay! Our products still work just fine.',
+		];
+	}
+
+	public function test_should_return_basic_defaults() {
+		$status = new Status();
+
+		$this->set_fn_return(
+			'wp_get_current_user',
+			static function () {
+				return new WP_User( 1, 'admin' );
+			},
+			true
+		);
+
+		update_option(
+			$status->get_option_name(),
+			[
+				'plugins' => [
+					'the-events-calendar' => [
+						'wp_slug' => 'the-events-calendar/the-events-calendar.php',
+						'optin'   => false,
+					],
+				],
+				'token'   => 'abcd1234',
+			]
+		);
+
+		$expected = $this->get_default_template_data();
+		$actual   = ( new Opt_In_Template( $status ) )->get_args( 'telemetry-library' );
+
+		$this->assertIsArray( $actual );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function test_get_intro() {
+		$expected = $this->get_default_template_data();
+		$actual   = ( new Opt_In_Template( new Status() ) )->get_intro( 'admin', 'StellarWP' );
+
+		$this->assertIsString( $actual );
+		$this->assertEquals( $expected['intro'], $actual );
+	}
+}


### PR DESCRIPTION
This adds the `opt_in_text` and properly passes that along in the opt-in request to support https://github.com/stellarwp/telemetry-server/pull/72