### PR TITLE
Revert "Sync Release Back to Develop"

### DIFF
--- a/src/Telemetry/Events/Event.php
+++ b/src/Telemetry/Events/Event.php
@@ -24,7 +24,7 @@ class Event {
 	/**
 	 * The hook name for sending events asyncronously.
 	 *
-	 * @since 2.2.0
+	 * @since TBD
 	 */
 	public const AJAX_ACTION = 'stellarwp_telemetry_send_event';
 
@@ -87,7 +87,7 @@ class Event {
 	/**
 	 * Send batched events.
 	 *
-	 * @since 2.2.0
+	 * @since TBD
 	 *
 	 * @param array $events An array of stored events to send to the telemetry server.
 	 *

--- a/src/Telemetry/Events/Event_Subscriber.php
+++ b/src/Telemetry/Events/Event_Subscriber.php
@@ -38,7 +38,7 @@ class Event_Subscriber extends Abstract_Subscriber {
 	/**
 	 * Caches an event to be sent during shutdown.
 	 *
-	 * @since 2.2.0
+	 * @since TBD
 	 *
 	 * @param string $name         The name of the event.
 	 * @param array  $data         The data sent along with the event.
@@ -64,7 +64,7 @@ class Event_Subscriber extends Abstract_Subscriber {
 	/**
 	 * Sends the events that have been stored for the current request.
 	 *
-	 * @since 2.2.0
+	 * @since TBD
 	 *
 	 * @return void
 	 */
@@ -93,7 +93,7 @@ class Event_Subscriber extends Abstract_Subscriber {
 	/**
 	 * Send the event to the telemetry server.
 	 *
-	 * @since 2.2.0
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Telemetry/Opt_In/Opt_In_Subscriber.php
+++ b/src/Telemetry/Opt_In/Opt_In_Subscriber.php
@@ -140,7 +140,7 @@ class Opt_In_Subscriber extends Abstract_Subscriber {
 	 *
 	 * @since 1.0.0
 	 * @since 2.0.0 - Updated to allow specifying the stellar slug.
-	 * @since 2.2.0 - Updated to add opt-in text.
+	 * @since TBD - Updated to add opt-in text.
 	 *
 	 * @param string $stellar_slug The slug to use when opting in.
 	 * @param string $opt_in_text  The text displayed to the user when they agreed to opt-in.

--- a/src/Telemetry/Opt_In/Status.php
+++ b/src/Telemetry/Opt_In/Status.php
@@ -65,7 +65,7 @@ class Status {
 	 *
 	 * @since 1.0.0
 	 * @since 2.0.1 Correct logic so it is not subject to the order of the plugins.
-	 * @since 2.2.0 Update to remove unnecessary "mixed" status.
+	 * @since TBD   Update to remove unnecessary "mixed" status.
 	 *
 	 * @return integer The status value.
 	 */

--- a/src/Telemetry/Telemetry/Telemetry.php
+++ b/src/Telemetry/Telemetry/Telemetry.php
@@ -94,9 +94,6 @@ class Telemetry {
 		$user_details = $this->get_user_details( $stellar_slug, $opt_in_text );
 
 		try {
-			// Store the user info in the options table.
-			update_option( Status::OPTION_NAME_USER_INFO, $user_details, false );
-
 			$this->send( $user_details, Config::get_server_url() . '/opt-in', false );
 		} catch ( \Error $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// We don't want to throw errors if the server fails.


### PR DESCRIPTION
Reverts stellarwp/telemetry#91, instead of trying to merge the specific release branch back into `develop`, it's better to sync `main` back into `develop` to keep commit history in sync.