### PR TITLE
Improve Test Coverage

### DIFF
--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -12,3 +12,7 @@ extensions:
         - Codeception\Command\GenerateWPUnit
 params:
     - .env.testing
+coverage:
+    enabled: true
+    include:
+      - src/Telemetry/*.php

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "lucatume/di52": "3.0.0",
     "lucatume/wp-browser": "^4.0",
     "phpcompatibility/phpcompatibility-wp": "*",
+    "phpunit/php-code-coverage": "^9.2",
     "szepeviktor/phpstan-wordpress": "^1.1",
     "the-events-calendar/coding-standards": "dev-master",
     "wp-coding-standards/wpcs": "^2.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ecfc08ca93841b5560a2cbf65dd91c7",
+    "content-hash": "56b094e5e073d9b93da823e682cf2470",
     "packages": [
         {
             "name": "stellarwp/container-contract",

--- a/src/Telemetry/Contracts/Template_Interface.php
+++ b/src/Telemetry/Contracts/Template_Interface.php
@@ -26,15 +26,6 @@ interface Template_Interface {
 	public function render( string $stellar_slug );
 
 	/**
-	 * Enqueues assets for the rendered template.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return void
-	 */
-	public function enqueue();
-
-	/**
 	 * Determines if the template should be rendered.
 	 *
 	 * @since 1.0.0

--- a/src/Telemetry/Exit_Interview/Template.php
+++ b/src/Telemetry/Exit_Interview/Template.php
@@ -136,17 +136,6 @@ class Template implements Template_Interface {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return void
-	 */
-	public function enqueue() {
-		// TODO: Implement enqueue() method.
-	}
-
-	/**
-	 * @inheritDoc
-	 *
-	 * @since 1.0.0
-	 *
 	 * @param string $stellar_slug The stellar slug for which the modal should be rendered.
 	 *
 	 * @return boolean

--- a/src/Telemetry/Opt_In/Opt_In_Template.php
+++ b/src/Telemetry/Opt_In/Opt_In_Template.php
@@ -44,15 +44,6 @@ class Opt_In_Template implements Template_Interface {
 	}
 
 	/**
-	 * @inheritDoc
-	 *
-	 * @return void
-	 */
-	public function enqueue(): void {
-		// TODO: Once FE template is done, enqueue it here.
-	}
-
-	/**
 	 * Gets the arguments for configuring how the Opt-In modal is rendered.
 	 *
 	 * @since 1.0.0

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -1,7 +1,10 @@
 <?php
-
-use Codeception\TestCase\WPTestCase;
+/**
+ * Handles all tests related to the Config class.
+ */
 use StellarWP\Telemetry\Config;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use StellarWP\Telemetry\Tests\Container;
 
 class ConfigTest extends WPTestCase {
 
@@ -28,9 +31,26 @@ class ConfigTest extends WPTestCase {
 		Config::get_container();
 	}
 
+	public function test_it_returns_true_with_container_set() {
+		Config::set_container( new Container() );
+
+		$this->assertTrue( Config::has_container() );
+	}
+
+	public function test_it_returns_true_with_no_container_set() {
+		$this->assertFalse( Config::has_container() );
+	}
+
 	public function test_it_should_set_stellar_slug() {
 		Config::set_stellar_slug( 'unique_slug' );
 
 		$this->assertEquals( 'unique_slug', Config::get_stellar_slug() );
+	}
+
+	public function test_it_should_add_stellar_slug() {
+		Config::add_stellar_slug( 'additional_stellar_slug', 'path/to/wp-slug' );
+
+		$this->assertIsArray( Config::get_all_stellar_slugs() );
+		$this->assertContains( 'additional_stellar_slug', array_keys( Config::get_all_stellar_slugs() ) );
 	}
 }

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -37,7 +37,7 @@ class ConfigTest extends WPTestCase {
 		$this->assertTrue( Config::has_container() );
 	}
 
-	public function test_it_returns_true_with_no_container_set() {
+	public function test_it_returns_false_with_no_container_set() {
 		$this->assertFalse( Config::has_container() );
 	}
 

--- a/tests/wpunit/CoreTest.php
+++ b/tests/wpunit/CoreTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Handles all tests related to the Core class.
+ */
+use StellarWP\Telemetry\Config;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use StellarWP\Telemetry\Core;
+use StellarWP\Telemetry\Tests\Container;
+
+class CoreTest extends WPTestCase {
+
+	public function test_it_throws_exception_without_container() {
+		$core = new Core();
+
+		$this->expectException( RuntimeException::class );
+		$core->init( '/some/path/to/plugin.php' );
+	}
+
+	public function test_it_returns_a_valid_instance() {
+		Config::set_container( new Container() );
+		$core = Config::get_container()->get( Core::class );
+		$this->assertInstanceOf( Core::class, $core->instance() );
+	}
+
+	public function test_it_returns_container_interface() {
+		Config::set_container( new Container() );
+		$core = Config::get_container()->get( Core::class );
+		$core->init( '/some/path/to/plugin.php' );
+
+		$this->assertInstanceOf( \StellarWP\ContainerContract\ContainerInterface::class, $core->container() );
+	}
+}

--- a/tests/wpunit/EventTest.php
+++ b/tests/wpunit/EventTest.php
@@ -1,5 +1,9 @@
 <?php
+/**
+ * Handles all tests related to event sending.
+ */
 
+use lucatume\WPBrowser\TestCase\WPTestCase;
 use StellarWP\Telemetry\Config;
 use StellarWP\Telemetry\Data_Providers\Null_Data_Provider;
 use StellarWP\Telemetry\Events\Event;
@@ -8,7 +12,7 @@ use StellarWP\Telemetry\Telemetry\Telemetry;
 use StellarWP\Telemetry\Tests\Support\Traits\With_Test_Container;
 use StellarWP\Telemetry\Tests\Support\Traits\With_Uopz;
 
-class EventTest extends \Codeception\TestCase\WPTestCase {
+class EventTest extends WPTestCase {
 
 	use With_Test_Container;
 	use With_Uopz;
@@ -71,5 +75,199 @@ class EventTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( Config::get_server_url() . '/events', $call_url );
 		$this->assertSame( $event_data, $call_args['body'] );
 		$this->assertTrue( $sent );
+	}
+
+	/**
+	 * It should return false with failed event send.
+	 *
+	 * @test
+	 */
+	public function should_return_false_with_failed_send() {
+		$mock_response = [
+			'headers'       => [],
+			'body'          => json_encode([]), // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+			'response'      => [
+				'code'    => false,
+				'message' => false,
+			],
+			'cookies'       => [],
+			'http_response' => null,
+		];
+		$call_url      = null;
+		$call_args     = null;
+		$this->set_fn_return(
+			'wp_remote_post',
+			static function ( string $url, array $args ) use ( $mock_response, &$call_url, &$call_args ) {
+				$call_url  = $url;
+				$call_args = $args;
+
+				return $mock_response;
+			},
+			true
+		);
+
+		$opt_in_status = new Status();
+		$telemetry     = new Telemetry( new Null_Data_Provider(), $opt_in_status );
+		$event         = new Event( $telemetry );
+
+		$opt_in_status->set_status( true );
+
+		$telemetry->save_token( 'abcd1234' );
+
+		$event_data = [
+			'token'        => 'abcd1234',
+			'stellar_slug' => Config::get_stellar_slug(),
+			'event'        => 'my-event',
+			'event_data'   => wp_json_encode(
+				[
+					'some' => 'data',
+				]
+			),
+		];
+
+		$sent = $event->send( 'my-event', [ 'some' => 'data' ] );
+
+		$this->assertEquals( Config::get_server_url() . '/events', $call_url );
+		$this->assertSame( $event_data, $call_args['body'] );
+		$this->assertFalse( $sent );
+	}
+
+
+	/**
+	 * It should successfully send a batch of events.
+	 *
+	 * @test
+	 */
+	public function should_send_batched_events() {
+		$mock_response = [
+			'headers'       => [],
+			'body'          => json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+				[
+					'status'  => 'true',
+					'message' => 'success',
+				]
+			),
+			'response'      => [
+				'code'    => false,
+				'message' => false,
+			],
+			'cookies'       => [],
+			'http_response' => null,
+		];
+		$call_url      = null;
+		$call_args     = null;
+		$this->set_fn_return(
+			'wp_remote_post',
+			static function ( string $url, array $args ) use ( $mock_response, &$call_url, &$call_args ) {
+				$call_url  = $url;
+				$call_args = $args;
+
+				return $mock_response;
+			},
+			true
+		);
+
+		$opt_in_status = new Status();
+		$telemetry     = new Telemetry( new Null_Data_Provider(), $opt_in_status );
+		$event         = new Event( $telemetry );
+
+		$opt_in_status->set_status( true );
+
+		$telemetry->save_token( 'abcd1234' );
+
+		$events = [
+			[
+				'stellar_slug' => 'the-events-calendar',
+				'event'        => 'event-created',
+				'event_data'   => wp_json_encode(
+					[
+						'title' => 'Annual Golf Tournament',
+					]
+				),
+			],
+			[
+				'stellar_slug' => 'give',
+				'event'        => 'published-donation-form',
+				'event_data'   => wp_json_encode(
+					[
+						'donation_amount' => '50000',
+					]
+				),
+			]
+		];
+
+		$expected_args = [
+			'token' => 'abcd1234',
+			'events' => $events,
+		];
+
+		$sent = $event->send_batch( $events );
+
+		$this->assertEquals( Config::get_server_url() . '/events', $call_url );
+		$this->assertSame( $expected_args, $call_args['body'] );
+		$this->assertTrue( $sent );
+	}
+
+	/**
+	 * It should successfully send a batch of events.
+	 *
+	 * @test
+	 */
+	public function should_return_false_with_failed_batch_send() {
+		$mock_response = [
+			'headers'       => [],
+			'body'          => json_encode([]), // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+			'response'      => [
+				'code'    => false,
+				'message' => false,
+			],
+			'cookies'       => [],
+			'http_response' => null,
+		];
+		$call_url      = null;
+		$call_args     = null;
+		$this->set_fn_return(
+			'wp_remote_post',
+			static function ( string $url, array $args ) use ( $mock_response, &$call_url, &$call_args ) {
+				$call_url  = $url;
+				$call_args = $args;
+
+				return $mock_response;
+			},
+			true
+		);
+
+		$opt_in_status = new Status();
+		$telemetry     = new Telemetry( new Null_Data_Provider(), $opt_in_status );
+		$event         = new Event( $telemetry );
+
+		$opt_in_status->set_status( true );
+
+		$telemetry->save_token( 'abcd1234' );
+
+		$events = [
+			[
+				'stellar_slug' => 'the-events-calendar',
+				'event'        => 'event-created',
+				'event_data'   => wp_json_encode(
+					[
+						'title' => 'Annual Golf Tournament',
+					]
+				),
+			],
+			[
+				'stellar_slug' => 'give',
+				'event'        => 'published-donation-form',
+				'event_data'   => wp_json_encode(
+					[
+						'donation_amount' => '50000',
+					]
+				),
+			]
+		];
+
+		$sent = $event->send_batch( $events );
+
+		$this->assertFalse( $sent );
 	}
 }

--- a/tests/wpunit/LastSendTest.php
+++ b/tests/wpunit/LastSendTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Handles all tests related to the Config class.
+ */
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use StellarWP\Telemetry\Last_Send\Last_Send;
+use StellarWP\Telemetry\Tests\Support\Traits\With_Uopz;
+
+class LastSendTest extends WPTestCase {
+
+	use With_Uopz;
+
+	public function test_it_initializes_option() {
+		$last_send = new Last_Send();
+
+		$option = get_option( Last_Send::OPTION_NAME );
+
+		$this->assertFalse( $option );
+
+		$last_send->initialize_option();
+
+		$option = get_option( Last_Send::OPTION_NAME );
+
+		$this->assertIsString( $option );
+	}
+
+	public function test_is_expired_with_empty_value() {
+
+		$last_send = new Last_Send();
+
+		update_option( Last_Send::OPTION_NAME, '' );
+
+		$this->assertTrue( $last_send->is_expired() );
+	}
+
+	public function test_is_expired_with_past_timestamp() {
+
+		$last_send = new Last_Send();
+
+		update_option( Last_Send::OPTION_NAME, DateTimeImmutable::createFromFormat( 'Y-m-d', '2020-01-01' )->format( 'Y-m-d H:i:s' ) );
+
+		$this->assertTrue( $last_send->is_expired() );
+
+	}
+
+	public function test_set_new_timestamp() {
+
+		$last_send = new Last_Send();
+		$time = new DateTimeImmutable();
+
+		$last_send->initialize_option();
+		$result = $last_send->set_new_timestamp( $time );
+
+		$this->assertIsInt( $result );
+		$this->assertSame( 1, $result );
+
+		$actual = $last_send->get_timestamp();
+
+		$this->assertSame( $time->format( 'Y-m-d H:i:s' ), $actual );
+
+	}
+
+	public function test_set_new_timestamp_returns_on_false_result() {
+		$last_send = new Last_Send();
+
+		$this->set_class_fn_return( wpdb::class, 'update', function() {
+			return false;
+		}, true);
+
+		$time = new DateTimeImmutable();
+		$actual = $last_send->set_new_timestamp( $time );
+
+		$this->assertSame( 0, $actual );
+	}
+}

--- a/tests/wpunit/TelemetrySubscriberTest.php
+++ b/tests/wpunit/TelemetrySubscriberTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tests all methods within the Telemetry Subscriber class.
+ */
+
+use StellarWP\Telemetry\Config;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use StellarWP\Telemetry\Telemetry\Telemetry;
+use StellarWP\Telemetry\Telemetry\Telemetry_Subscriber;
+use StellarWP\Telemetry\Tests\Support\Traits\With_Uopz;
+use StellarWP\Telemetry\Tests\Support\Traits\With_Test_Container;
+
+class TelemetrySubscriberTest extends WPTestCase {
+
+	use With_Uopz;
+	use With_Test_Container;
+
+	/**
+	 * @dataProvider subscriber_hooks_data_provider
+	 */
+	public function test_register_adds_necessary_hooks( $hook, $method) {
+		$subscriber = new Telemetry_Subscriber( Config::get_container() );
+
+		$hooks = [];
+
+		$this->set_fn_return( 'add_action', function( $hook_name, $function_to_add, $priority = 10, $accepted_args = 0 ) use ( &$hooks ) {
+			$hooks[ $hook_name ] = $function_to_add;
+		}, true );
+
+		$subscriber->register();
+
+		$this->assertArrayHasKey( $hook, $hooks );
+		$this->assertInstanceOf( $method[0], $hooks[$hook][0] );
+		$this->assertSame( $method[1], $hooks[$hook][1] );
+	}
+
+	public function test_send_async_request() {
+		$mock_response = [
+			'headers'       => [],
+			'body'          => json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+				[
+					'status' => 'success',
+					'token'  => '1234567890',
+				]
+			),
+			'response'      => [
+				'code'    => false,
+				'message' => false,
+			],
+			'cookies'       => [],
+			'http_response' => null,
+		];
+
+		$call_url  = '';
+		$call_args = [];
+
+		$this->set_fn_return( 'wp_remote_request', function( $url, $args ) use ( $mock_response, &$call_url, &$call_args ) {
+			$call_url  = $url;
+			$call_args = $args;
+
+			return $mock_response;
+		}, true );
+
+		$subscriber = new Telemetry_Subscriber( Config::get_container() );
+
+		$subscriber->send_async_request();
+	}
+
+	public function subscriber_hooks_data_provider() {
+		return [
+			[ 'shutdown', [ Telemetry_Subscriber::class, 'send_async_request'] ],
+			[ 'wp_ajax_' . Telemetry::AJAX_ACTION, [ Telemetry_Subscriber::class, 'send_telemetry_data'] ],
+			[ 'wp_ajax_nopriv_' . Telemetry::AJAX_ACTION, [ Telemetry_Subscriber::class, 'send_telemetry_data'] ],
+		];
+	}
+
+
+
+}

--- a/tests/wpunit/TelemetrySubscriberTest.php
+++ b/tests/wpunit/TelemetrySubscriberTest.php
@@ -73,7 +73,4 @@ class TelemetrySubscriberTest extends WPTestCase {
 			[ 'wp_ajax_nopriv_' . Telemetry::AJAX_ACTION, [ Telemetry_Subscriber::class, 'send_telemetry_data'] ],
 		];
 	}
-
-
-
 }

--- a/tests/wpunit/Telemetry_Test.php
+++ b/tests/wpunit/Telemetry_Test.php
@@ -2,7 +2,6 @@
 
 use Codeception\TestCase\WPTestCase;
 use StellarWP\Telemetry\Config;
-use StellarWP\Telemetry\Data_Providers\Debug_Data;
 use StellarWP\Telemetry\Data_Providers\Null_Data_Provider;
 use StellarWP\Telemetry\Opt_In\Status;
 use StellarWP\Telemetry\Telemetry\Telemetry;

--- a/tests/wpunit/TemplateTest.php
+++ b/tests/wpunit/TemplateTest.php
@@ -169,7 +169,5 @@ class TemplateTest extends WPTestCase {
 		$this->assertSame( '/var/www/html/wp-content/plugins/telemetry/src/views/optin.php', $file );
 		$this->assertSame( false, $require );
 		$this->assertSame( $template->get_args( 'telemetry-library' ), $arguments );
-
-		update_option( $template->get_option_name( 'telemetry-library' ), false );
 	}
 }

--- a/tests/wpunit/TemplateTest.php
+++ b/tests/wpunit/TemplateTest.php
@@ -13,6 +13,8 @@ class TemplateTest extends WPTestCase {
 	use With_Test_Container;
 	use With_Uopz;
 
+	public const PLUGIN_SLUG = 'telemetry-library';
+
 	public function get_default_template_data() {
 		return [
 			'plugin_logo'           => Resources::get_asset_path() . 'resources/images/stellar-logo.svg',
@@ -20,7 +22,7 @@ class TemplateTest extends WPTestCase {
 			'plugin_logo_height'    => 32,
 			'plugin_logo_alt'       => 'StellarWP Logo',
 			'plugin_name'           => 'StellarWP',
-			'plugin_slug'           => 'telemetry-library',
+			'plugin_slug'           => self::PLUGIN_SLUG,
 			'user_name'             => 'admin',
 			'permissions_url'       => '#',
 			'tos_url'               => '#',
@@ -60,7 +62,7 @@ class TemplateTest extends WPTestCase {
 		);
 
 		$expected = $this->get_default_template_data();
-		$actual   = ( new Opt_In_Template( $status ) )->get_args( 'telemetry-library' );
+		$actual   = ( new Opt_In_Template( $status ) )->get_args( self::PLUGIN_SLUG );
 
 		$this->assertIsArray( $actual );
 		$this->assertEquals( $expected, $actual );
@@ -105,30 +107,30 @@ class TemplateTest extends WPTestCase {
 			true
 		);
 
-		$template->render( 'telemetry-library' );
+		$template->render( self::PLUGIN_SLUG );
 
 		$this->assertSame( '/var/www/html/wp-content/plugins/telemetry/src/views/optin.php', $file );
 		$this->assertSame( false, $require );
-		$this->assertSame( $template->get_args( 'telemetry-library' ), $arguments );
+		$this->assertSame( $template->get_args( self::PLUGIN_SLUG ), $arguments );
 	}
 
 	public function test_get_option_name() {
 		$template = Config::get_container()->get( Opt_In_Template::class );
 
-		$this->assertSame( 'stellarwp_telemetry_telemetry-library_show_optin', $template->get_option_name( 'telemetry-library' ) );
+		$this->assertSame( 'stellarwp_telemetry_' . self::PLUGIN_SLUG . '_show_optin', $template->get_option_name( self::PLUGIN_SLUG ) );
 	}
 
 	public function test_should_render() {
 		$template = Config::get_container()->get( Opt_In_Template::class );
-		$option_name = $template->get_option_name( 'telemetry-library' );
+		$option_name = $template->get_option_name( self::PLUGIN_SLUG );
 
 		update_option( $option_name, true );
 
-		$this->assertTrue( $template->should_render( 'telemetry-library' ) );
+		$this->assertTrue( $template->should_render( self::PLUGIN_SLUG ) );
 
 		update_option( $option_name, false );
 
-		$this->assertFalse( $template->should_render( 'telemetry-library' ) );
+		$this->assertFalse( $template->should_render( self::PLUGIN_SLUG ) );
 	}
 
 	public function test_maybe_render() {
@@ -148,7 +150,7 @@ class TemplateTest extends WPTestCase {
 			]
 		);
 
-		update_option( $template->get_option_name( 'telemetry-library' ), true);
+		update_option( $template->get_option_name( self::PLUGIN_SLUG ), true);
 
 		$file      = null;
 		$require   = null;
@@ -164,10 +166,10 @@ class TemplateTest extends WPTestCase {
 			true
 		);
 
-		$template->maybe_render( 'telemetry-library' );
+		$template->maybe_render( self::PLUGIN_SLUG );
 
 		$this->assertSame( '/var/www/html/wp-content/plugins/telemetry/src/views/optin.php', $file );
 		$this->assertSame( false, $require );
-		$this->assertSame( $template->get_args( 'telemetry-library' ), $arguments );
+		$this->assertSame( $template->get_args( self::PLUGIN_SLUG ), $arguments );
 	}
 }


### PR DESCRIPTION
This handles setting up code coverage measuring and improves our test coverage quite a bit.

You can verify this locally with Slic.

First, you'll need to start XDebug to use it as a driver with:
```sh
slic xdebug on
```

Then you can run the tests and generate the coverage report in the `tests/_output` directory:
```sh
slic run --coverage-html tests/_output
```

<img width="1619" alt="image" src="https://github.com/stellarwp/telemetry/assets/6947218/70dee8de-06d1-4aa5-a551-74bb32468f7f">

