### PR TITLE
Install zip in lando environment

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -27,6 +27,9 @@ services:
       environment:
         PHP_IDE_CONFIG: "serverName=telemetry-library"
         XDEBUG_SESSION_START: lando
+    build_as_root:
+      - apt-get update -y
+      - apt-get install zip
 
   mailhog:
     type: mailhog


### PR DESCRIPTION
With the new QA process zipping up the `library-testing` plugin, `wp dist-archive` needs the `zip` utility for it to compress the plugin.