### PR TITLE
Keep di52 compatibility

### DIFF
--- a/src/Telemetry/Events/Event_Subscriber.php
+++ b/src/Telemetry/Events/Event_Subscriber.php
@@ -106,6 +106,14 @@ class Event_Subscriber extends Abstract_Subscriber {
 		// Get the passed event array.
 		$events = filter_input( INPUT_POST, 'events', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY ); // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.RestrictedFilter
 
-		$this->container->get( Event::class )->send_batch( $events ?: [] );
+		if ( empty( $events ) ) {
+				return;
+		}
+		
+		if ( ! is_array( $events ) ) {
+				$events = (array) $events;
+		}
+
+		$this->container->get( Event::class )->send_batch( $events );
 	}
 }

--- a/src/Telemetry/Events/Event_Subscriber.php
+++ b/src/Telemetry/Events/Event_Subscriber.php
@@ -22,10 +22,6 @@ use StellarWP\Telemetry\Contracts\Abstract_Subscriber;
 class Event_Subscriber extends Abstract_Subscriber {
 
 	/**
-	 * Holds the events in a non-persistent way.
-	 *
-	 * @since 2.3.1
-	 *
 	 * @var array
 	 */
 	private static $events = [];
@@ -107,11 +103,11 @@ class Event_Subscriber extends Abstract_Subscriber {
 		$events = filter_input( INPUT_POST, 'events', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY ); // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.RestrictedFilter
 
 		if ( empty( $events ) ) {
-				return;
+			return;
 		}
-		
+
 		if ( ! is_array( $events ) ) {
-				$events = (array) $events;
+			$events = (array) $events;
 		}
 
 		$this->container->get( Event::class )->send_batch( $events );

--- a/src/Telemetry/Events/Event_Subscriber.php
+++ b/src/Telemetry/Events/Event_Subscriber.php
@@ -106,10 +106,6 @@ class Event_Subscriber extends Abstract_Subscriber {
 			return;
 		}
 
-		if ( ! is_array( $events ) ) {
-			$events = (array) $events;
-		}
-
-		$this->container->get( Event::class )->send_batch( $events );
+		$this->container->get( Event::class )->send_batch( (array) $events );
 	}
 }

--- a/src/Telemetry/Events/Event_Subscriber.php
+++ b/src/Telemetry/Events/Event_Subscriber.php
@@ -51,15 +51,11 @@ class Event_Subscriber extends Abstract_Subscriber {
 	 * @return void
 	 */
 	public function cache_event( $name, $data ) {
-		$events = [];
-
 		self::$events[] = [
 			'name'         => $name,
 			'data'         => wp_json_encode( $data ),
 			'stellar_slug' => Config::get_stellar_slug(),
 		];
-
-		self::$events = $events;
 	}
 
 	/**

--- a/src/Telemetry/Events/Event_Subscriber.php
+++ b/src/Telemetry/Events/Event_Subscriber.php
@@ -21,6 +21,13 @@ use StellarWP\Telemetry\Contracts\Abstract_Subscriber;
  */
 class Event_Subscriber extends Abstract_Subscriber {
 
+	/**
+	 * Holds the events in a non-persistent way.
+	 *
+	 * @since 2.3.1
+	 *
+	 * @var array
+	 */
 	private static $events = [];
 
 	/**


### PR DESCRIPTION
This removes the use of `bind()` in a way that is not compatible with di52 containers. 

This is causing fatals in TEC product as they use the di52 container and bind always tries to build a class ( it would use getVar/setVar instead)

It also adds a safety net on `send_events()` in the case where `$events` is null.

[BTRIA-2105]

[BTRIA-2105]: https://stellarwp.atlassian.net/browse/BTRIA-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ