### PR TITLE
Fix event testing functionality

### DIFF
--- a/dev/public/wp-content/plugins/library-testing/src/Settings_Page.php
+++ b/dev/public/wp-content/plugins/library-testing/src/Settings_Page.php
@@ -102,7 +102,7 @@ class Settings_Page {
 
 		// Send the event.
 		for ( $i = 0; $i < $number; $i++ ) {
-			do_action( 'stellarwp/telemetry/telemetry-library/event', $event_key, $event_data );
+			do_action( 'stellarwp/telemetry/' . Config::get_hook_prefix() . '/event', $event_key, $event_data );
 		}
 	}
 


### PR DESCRIPTION
The hook prefix used in the `do_action()` was wrong so events were never actually sending correctly. This fixes the issue in the test plugin.