### PR TITLE
Update blues to Liquid Web brand colors

### DIFF
--- a/src/resources/css/styles.css
+++ b/src/resources/css/styles.css
@@ -75,7 +75,7 @@
 .stellarwp-telemetry-btn-grey,
 .stellarwp-telemetry-btn-text {
 	padding: 8px 12px;
-	background: #0047FF;
+	background: #1145C9;
 	border-radius: 4px;
 	color: #fff;
 	text-decoration: none;
@@ -86,12 +86,12 @@
 }
 
 .stellarwp-telemetry-btn-primary:hover {
-	background: #0032b7;
+	background: #0E38A3;
 }
 
 .stellarwp-telemetry-btn-primary:disabled,
 .stellarwp-telemetry-btn-primary.disabled {
-	background:rgba(0, 71, 255, 0.5);
+	background: rgba(17, 69, 201, 0.5);
 	pointer-events: none;
 }
 
@@ -105,14 +105,13 @@
 }
 
 .stellarwp-telemetry-btn-text {
-	background: #fff;
-	color: #4E4E4E;
+	background: transparent;
+	color: #1145C9;
 	padding: 0;
 }
 
 .stellarwp-telemetry-btn-text--skip {
 	margin-left: 1rem;
-	color: #a7aaad;
 }
 
 .stellarwp-telemetry-btn-text:hover {
@@ -175,7 +174,7 @@
 }
 
 .stellarwp-telemetry-links__link {
-	color: #0047FF;
+	color: #1145C9;
 	text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary

Updates all blue color values in the telemetry modal CSS to match the new Liquid Web brand palette
- Primary base: `#0047FF` → `#1145C9`
- Primary hover: `#0032b7` → `#0E38A3`
- Primary disabled: `rgba(0, 71, 255, 0.5)` → `rgba(17, 69, 201, 0.5)`
- Link color: `#0047FF` → `#1145C9`

Old

<img width="500" height="322" alt="image" src="https://github.com/user-attachments/assets/01c0ae5b-32f6-4b82-a238-8ac00ad59eae" />

New

<img width="497" height="321" alt="image" src="https://github.com/user-attachments/assets/e51e0170-8462-4529-89b2-eea0c7840d49" />

## Test plan
- [x] Verify opt-in modal renders with correct blue colors
- [x] Verify button hover and disabled states
- [x] Verify link colors in the modal
- [x] Verify exit interview modal styling
- [x] Check WCAG contrast compliance of new colors against modal backgrounds